### PR TITLE
Add an application level logger (winston)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@reactivex/rxjs": "^5.0.0-beta.10",
     "@types/hapi": "^13.0.27-alpha",
     "@types/knex": "0.0.28",
+    "@types/winston": "0.0.27",
     "adm-zip": "^0.4.7",
     "deepcopy": "^0.6.3",
     "good": "^7.0.1",
@@ -23,7 +24,8 @@
     "mkpath": "^1.0.0",
     "pg": "^6.0.3",
     "reflect-metadata": "^0.1.3",
-    "url-join": "^1.1.0"
+    "url-join": "^1.1.0",
+    "winston": "^2.2.0"
   },
   "devDependencies": {
     "@types/chai": "^3.4.28",

--- a/src/app.ts
+++ b/src/app.ts
@@ -28,6 +28,8 @@ import MinardServer, {hostInjectSymbol, portInjectSymbol} from './server/server'
 
 import { GitlabClient, fetchInjectSymbol, gitlabHostInjectSymbol } from './shared/gitlab-client';
 
+import Logger, { loggerInjectSymbol } from './shared/logger';
+
 const kernel = new Kernel();
 
 // We are injecting the eventBus here as a constantValue as the
@@ -40,6 +42,7 @@ const kernel = new Kernel();
 //
 //  -- JO 25.6.2016
 kernel.bind(EventBus.injectSymbol).toConstantValue(new LocalEventBus());
+kernel.bind(loggerInjectSymbol).toConstantValue(Logger(undefined, false, process.env.DEBUG ? true : false));
 kernel.bind(DeploymentPlugin.injectSymbol).to(DeploymentPlugin);
 kernel.bind(DeploymentModule.injectSymbol).to(DeploymentModule);
 kernel.bind(DeploymentJsonApi.injectSymbol).to(DeploymentJsonApi);

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -1,0 +1,16 @@
+import * as winston from 'winston';
+
+export const loggerInjectSymbol = Symbol();
+export type Logger = winston.LoggerInstance;
+
+export default (options?: winston.LoggerOptions, silent?: boolean, debug?: boolean) => new winston.Logger(options || {
+  transports: [
+    new winston.transports.Console({
+      level: debug ? 'debug' : 'info',
+      colorize: true,
+      timestamp: true,
+      prettyPrint: true,
+      silent: silent ? true : false,
+    }),
+  ],
+});


### PR DESCRIPTION
Adds a logger constructor and types to the `shared/logger.ts` file and sets up a default console logger with the DI container.
