### PR TITLE
Add support for repo-url attribute in projects

### DIFF
--- a/src/config/config-production.ts
+++ b/src/config/config-production.ts
@@ -9,7 +9,7 @@ import {
 } from '../deployment';
 
 import { externalBaseUrlInjectSymbol, goodOptionsInjectSymbol, hostInjectSymbol, portInjectSymbol} from '../server';
-import { gitlabHostInjectSymbol } from '../shared/gitlab-client';
+import { gitBaseUrlInjectSymbol, gitlabHostInjectSymbol } from '../shared/gitlab-client';
 import { loggerInjectSymbol } from '../shared/logger';
 import { systemHookBaseUrlSymbol } from '../system-hook/system-hook-module';
 
@@ -95,6 +95,9 @@ const SCREENSHOTTER_BASEURL = env.SCREENSHOTTER_BASEURL ? env.SCREENSHOTTER_BASE
 // Generic external base URL for charles
 const EXTERNAL_BASEURL = env.EXTERNAL_BASEURL ? env.EXTERNAL_BASEURL : `http://localhost:${PORT}`;
 
+// External baseUrl for git clone urls
+const EXTERNAL_GIT_BASEURL = env.EXTERNAL_GIT_BASEURL ? env.EXTERNAL_GIT_BASEURL : `http://localhost:${GITLAB_PORT}`;
+
 // URL pattern used for composing external deployment URLs
 // Users access deployments via urls matching this pattern
 const DEPLOYMENT_URL_PATTERN = env.DEPLOYMENT_URL_PATTERN ? env.DEPLOYMENT_URL_PATTERN
@@ -163,4 +166,5 @@ export default (kernel: interfaces.Kernel) => {
   kernel.bind(externalBaseUrlInjectSymbol).toConstantValue(EXTERNAL_BASEURL);
   kernel.bind(deploymentUrlPatternInjectSymbol).toConstantValue(DEPLOYMENT_URL_PATTERN);
   kernel.bind(screenshotUrlPattern).toConstantValue(SCREENSHOT_URL_PATTERN);
+  kernel.bind(gitBaseUrlInjectSymbol).toConstantValue(EXTERNAL_GIT_BASEURL);
 };

--- a/src/json-api/json-api-module-spec.ts
+++ b/src/json-api/json-api-module-spec.ts
@@ -343,6 +343,7 @@ describe('json-api-module', () => {
       const minardProject = {
         id: 1,
         latestActivityTimestamp: 'fake-timestamp',
+        repoUrl: 'http://foo-repo/foo/bar.git',
       } as MinardProject;
       const minardDeployment = {
         id: 5,
@@ -380,6 +381,7 @@ describe('json-api-module', () => {
       expect(project.latestSuccessfullyDeployedCommit!.deployments).to.have.length(1);
       expect(project.latestSuccessfullyDeployedCommit!.deployments[0].id)
         .to.equal(`${minardProject.id}-${minardDeployment.id}`);
+      expect(project.repoUrl).to.equal(minardProject.repoUrl);
     });
   });
 

--- a/src/json-api/json-api-module.ts
+++ b/src/json-api/json-api-module.ts
@@ -280,6 +280,7 @@ export class JsonApiModule {
       latestSuccessfullyDeployedCommit,
       activeCommitters: project.activeCommitters,
       description: project.description,
+      repoUrl: project.repoUrl,
     };
   }
 

--- a/src/json-api/serialization-spec.ts
+++ b/src/json-api/serialization-spec.ts
@@ -106,6 +106,7 @@ const exampleProject = {
       email: 'fooma@barmail.com',
     },
   ],
+  repoUrl: 'http://foo-bar.com/foo/bar.git',
 } as ApiProject;
 
 exampleCommitOne.deployments = [exampleDeploymentOne];
@@ -138,6 +139,7 @@ describe('json-api serialization', () => {
       // attributes
       expect(data.attributes.name).to.equal('example-project');
       expect(data.attributes['latest-activity-timestamp']).to.equal(project.latestActivityTimestamp);
+      expect(data.attributes['repo-url']).to.equal(project.repoUrl);
 
       // branches relationship
       expect(data.relationships).to.exist;
@@ -178,6 +180,7 @@ describe('json-api serialization', () => {
         'latestActivityTimestamp': '2016-09-01T13:12:32.521+05:30',
         'activeCommitters': [],
         'description': 'dsafjdsahfj',
+        'repoUrl': 'http://foo-bar.com/foo/bar.git',
       };
       const converted = serializeApiEntity('project', project, apiBaseUrl);
       const data = converted.data;
@@ -188,6 +191,7 @@ describe('json-api serialization', () => {
       expect(data.attributes.name).to.equal(project.name);
       expect(data.attributes['latest-activity-timestamp']).to.equal(project.latestActivityTimestamp);
       expect(data.attributes.description).to.equal(project.description);
+      expect(data.attributes['repo-url']).to.equal(project.repoUrl);
     });
 
   });

--- a/src/json-api/serialization.ts
+++ b/src/json-api/serialization.ts
@@ -84,7 +84,8 @@ export const projectSerialization = (apiBaseUrl: string) => {
       'branches',
       'activeCommitters',
       'latestActivityTimestamp',
-      'latestSuccessfullyDeployedCommit'],
+      'latestSuccessfullyDeployedCommit',
+      'repoUrl'],
     branches: {
       ignoreRelationshipData: true,
       ref: linkRef,

--- a/src/project/project-module-spec.ts
+++ b/src/project/project-module-spec.ts
@@ -48,7 +48,8 @@ function genericArrangeProjectModule(status: number, body: any, path: string) {
       {} as SystemHookModule,
       {} as LocalEventBus,
       gitlabClient,
-      logger);
+      logger,
+      '');
     fetchMock.restore();
     fetchMock.mock(
       `${host}${gitlabClient.apiPrefix}${path}`,
@@ -174,7 +175,8 @@ describe('project-module', () => {
         {} as SystemHookModule,
         {} as LocalEventBus,
         {} as GitlabClient,
-        logger);
+        logger,
+        '');
 
       // Act
       const commit = projectModule.toMinardCommit(gitlabCommit);
@@ -269,7 +271,8 @@ describe('project-module', () => {
         {} as SystemHookModule,
         {} as LocalEventBus,
         gitlabClient,
-        logger);
+        logger,
+        '');
       fetchMock.restore();
       fetchMock.mock(
         `${host}${gitlabClient.apiPrefix}/projects/3`,
@@ -560,7 +563,8 @@ describe('project-module', () => {
         {} as any,
         {} as any,
         {} as any,
-        {} as any);
+        {} as any,
+        '');
       let called = false;
 
       projectModule.fetchBranchCommits = async (
@@ -688,7 +692,8 @@ describe('project-module', () => {
         {} as any,
         {} as any,
         {} as any,
-        {} as any);
+        {} as any,
+        '');
       projectModule.fetchBranchCommits = async (
         _projectId: number, _branchName: string, _until: moment.Moment, _count: number) => {
         expect(_projectId).to.equal(projectId);
@@ -809,7 +814,8 @@ describe('project-module', () => {
         {} as SystemHookModule,
         {} as LocalEventBus,
         gitlabClient,
-        logger);
+        logger,
+        '');
       fetchMock.restore().mock(
         `${host}${gitlabClient.apiPrefix}/projects/${projectId}/repository/contributors`,
         { status, body });
@@ -859,7 +865,8 @@ describe('project-module', () => {
       {} as SystemHookModule,
       bus,
       client,
-      logger);
+      logger,
+      '');
     const mockUrl = `${host}${client.apiPrefix}${url}`;
     fetchMock.restore().mock(
       mockUrl,
@@ -976,7 +983,8 @@ describe('project-module', () => {
         {} as SystemHookModule,
         bus,
         client,
-        logger);
+        logger,
+        '');
       const mockUrl = `${host}${client.apiPrefix}/projects/${projectId}`;
       fetchMock.restore().mock(
         mockUrl,

--- a/src/project/types.ts
+++ b/src/project/types.ts
@@ -32,6 +32,7 @@ export const projectDeleted =
 export interface MinardProjectPlain {
   name: string;
   path: string;
+  repoUrl: string;
   description: string;
   latestActivityTimestamp: string;
   activeCommitters: MinardProjectContributor[];

--- a/src/realtime/realtime-hapi-plugin-spec.ts
+++ b/src/realtime/realtime-hapi-plugin-spec.ts
@@ -52,6 +52,7 @@ describe('realtime-hapi-plugin', () => {
                 name: 'foo',
                 email: 'foo',
               }],
+              repoUrl: 'foo',
           }),
         });
         const eventBus = new LocalEventBus();

--- a/src/shared/gitlab-client.ts
+++ b/src/shared/gitlab-client.ts
@@ -9,6 +9,7 @@ import { fetchInjectSymbol } from '../shared/types';
 const perfy = require('perfy');
 const randomstring = require('randomstring');
 
+export const gitBaseUrlInjectSymbol = Symbol('git-base-url');
 export const gitlabHostInjectSymbol = Symbol('gitlab-host');
 
 const urljoin = require('url-join');


### PR DESCRIPTION
This required a new environment variable `EXTERNAL_GIT_BASEURL`.

We need to defined that in Q/A, for this to return correct URLs also there.
