### PR TITLE
Exclude gitlab-data

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,8 @@
 {
+  "exclude": [
+    "gitlab-data",
+    "node_modules"
+  ],
   "compilerOptions": {
     "outDir": "./dist/",
     "sourceMap": true,


### PR DESCRIPTION
We don't want to compile any Gitlab or deployment files. By default, `exclude` includes node_modules, jspm_packages and bower_components. We need to add node_modules manually now.
