### PR TITLE
Change screenshot aspect ratio and increase renderDelay to 5 seconds

### DIFF
--- a/src/screenshot/screenshot-module.ts
+++ b/src/screenshot/screenshot-module.ts
@@ -84,7 +84,11 @@ export default class ScreenshotModule {
       const file = this.getScreenshotterPath(projectId, deploymentId);
       const webshotOptions = {
         defaultWhiteBackground: true,
-        renderDelay: 2000,
+        renderDelay: 5000,
+        windowSize: {
+          width: 1200,
+          height: 750,
+        },
       };
       await this.screenshotter.webshot(url, file, webshotOptions);
       return this.getPublicUrl(projectId, deploymentId);


### PR DESCRIPTION
Easiest way to test is to run integration tests and access the screenshot from the URL outputted by the integration test while it is running.
