### PR TITLE
Don't store deployment urls along activity

### DIFF
--- a/src/activity/activity-module-spec.ts
+++ b/src/activity/activity-module-spec.ts
@@ -118,7 +118,7 @@ describe('activity-module', () => {
     const knex = await setupKnex();
     await Promise.all(activities.map(item => knex('activity').insert(toDbActivity(item))));
     const deploymentModule = {} as DeploymentModule;
-    deploymentModule.toFullMinardDeployment = (_deployment: any) => {
+    deploymentModule.addUrlsToDeployment = (_deployment: any) => {
       return Object.assign({}, _deployment, { url: deploymentUrl });
     };
 

--- a/src/activity/activity-module.ts
+++ b/src/activity/activity-module.ts
@@ -114,10 +114,10 @@ export default class ActivityModule {
     this.eventBus.post(createActivityEvent(activity));
   }
 
-  public toFullMinardActivity(row: any) {
+  private toFullMinardActivity(row: any) {
     const activity = toMinardActivity(row);
 
-    const deployment = this.deploymentModule.toFullMinardDeployment(activity.deployment);
+    const deployment = this.deploymentModule.addUrlsToDeployment(activity.deployment);
     const ret = Object.assign({}, activity, {
       deployment,
     });


### PR DESCRIPTION
With this PR deployment and screenshot URLs are no more stored in the database along activity items. 

This prevents problems if old deployment URLs change in the future.
