### PR TITLE
Add comment-count into json api deployment entity

### DIFF
--- a/src/comment/comment-module.ts
+++ b/src/comment/comment-module.ts
@@ -97,8 +97,14 @@ export class CommentModule {
     const comments = await this.knex.select('*')
       .from('comment')
       .where('deploymentId', deploymentId)
+      .andWhere('status', 'n')
       .orderBy('id', 'DESC');
     return comments.map(toMinardComment);
+  }
+
+  public async getCommentCountForDeployment(deploymentId: number): Promise<number> {
+    const comments = await this.getCommentsForDeployment(deploymentId);
+    return comments.length;
   }
 
 }

--- a/src/json-api/json-api-module.ts
+++ b/src/json-api/json-api-module.ts
@@ -246,10 +246,10 @@ export class JsonApiModule {
     return ret;
   }
 
-  // TODO: this method does not need to be async
   public async toApiDeployment(
     projectId: number,
     deployment: MinardDeployment): Promise<ApiDeployment> {
+    const commentCount = await this.commentModule.getCommentCountForDeployment(deployment.id);
     return {
       id: `${projectId}-${deployment.id}`,
       commitHash: deployment.commitHash,
@@ -261,6 +261,7 @@ export class JsonApiModule {
       buildStatus: deployment.buildStatus,
       extractionStatus: deployment.buildStatus,
       screenshotStatus: deployment.screenshotStatus,
+      commentCount,
     };
   }
 

--- a/src/json-api/serialization-spec.ts
+++ b/src/json-api/serialization-spec.ts
@@ -35,6 +35,7 @@ const exampleDeploymentOne = {
     email: 'fooman@gmail.com',
     timestamp: '2015-12-24T17:54:31.198Z',
   },
+  commentCount: 2,
 } as {} as ApiDeployment;
 
 const exampleDeploymentTwo = {
@@ -46,6 +47,7 @@ const exampleDeploymentTwo = {
     email: 'barwoman@gmail.com',
     timestamp: '2015-12-24T17:55:31.198Z',
   },
+  commentCount: 4,
 } as {} as ApiDeployment;
 
 const exampleCommitOne = {
@@ -228,6 +230,7 @@ describe('json-api serialization', () => {
       expect(data[0].attributes.url).to.equal(exampleDeploymentOne.url);
       expect(data[0].attributes.creator).to.deep.equal(exampleDeploymentOne.creator);
       expect(data[0].attributes.screenshot).to.equal(exampleDeploymentOne.screenshot);
+      expect(data[0].attributes['comment-count']).to.equal(exampleDeploymentOne.commentCount);
 
       // no relationships or includes
       expect(data[0].relationships).to.not.exist;
@@ -362,7 +365,11 @@ describe('json-api serialization', () => {
       // attributes
       expect(data.attributes.timestamp).to.equal(activity.timestamp);
       expect(data.attributes['activity-type']).to.equal(activity.activityType);
-      expect(data.attributes.deployment).to.deep.equal(activity.deployment);
+      expect(data.attributes.deployment.id).to.equal(activity.deployment.id);
+      expect(data.attributes.deployment.url).to.equal(activity.deployment.url);
+      expect(data.attributes.deployment.screenshot).to.equal(activity.deployment.screenshot);
+      expect(data.attributes.deployment.status).to.equal(activity.deployment.status);
+      expect(data.attributes.deployment.creator).to.deep.equal(activity.deployment.creator);
       expect(data.attributes.project).to.deep.equal(activity.project);
       expect(data.attributes.branch).to.deep.equal(activity.branch);
       expect(data.attributes.commit).to.deep.equal(activity.commit);

--- a/src/json-api/serialization.ts
+++ b/src/json-api/serialization.ts
@@ -31,7 +31,7 @@ export const nonIncludedSerialization = {
 
 export const deploymentSerialization =  {
   attributes: ['status', 'commit', 'url', 'creator',
-  'screenshot', 'buildStatus', 'extractionStatus', 'screenshotStatus'],
+  'screenshot', 'buildStatus', 'extractionStatus', 'screenshotStatus', 'commentCount'],
   ref: standardIdRef,
   included: true,
 };

--- a/src/json-api/types.ts
+++ b/src/json-api/types.ts
@@ -70,6 +70,7 @@ export interface ApiDeployment {
   creator: MinardDeploymentCreator;
   // this is not exposed in serialized responses, but it is internally helpful
   commitHash: string;
+  commentCount?: number;
 }
 
 export interface ApiCommit extends MinardCommit {

--- a/src/json-api/view-endpoints-spec.ts
+++ b/src/json-api/view-endpoints-spec.ts
@@ -8,11 +8,23 @@ import {
 } from './json-api-module';
 
 import {
+  CommentModule,
+} from '../comment';
+
+import {
   DeploymentModule,
   MinardDeployment,
 } from '../deployment';
 
 import { ViewEndpoints } from './view-endpoints';
+
+function getMockCommentModule() {
+  const commentModule = {} as CommentModule;
+  commentModule.getCommentCountForDeployment = async (deploymentId: number) => {
+    return 2;
+  };
+  return commentModule;
+}
 
 describe('view-endpoints', () => {
 
@@ -63,7 +75,7 @@ describe('view-endpoints', () => {
       {} as any,
       {} as any,
       {} as any,
-      {} as any);
+      getMockCommentModule());
     const viewEndpoints = new ViewEndpoints(jsonApiModule, deploymentModule, 'foo-base-url');
 
     // Act

--- a/src/realtime/realtime-hapi-plugin-spec.ts
+++ b/src/realtime/realtime-hapi-plugin-spec.ts
@@ -22,6 +22,10 @@ import { RealtimeHapiPlugin } from './realtime-hapi-plugin';
 import { promisify } from '../shared/promisify';
 
 import {
+  CommentModule,
+} from '../comment';
+
+import {
   DeploymentEvent,
   createDeploymentEvent,
 } from '../deployment';
@@ -42,6 +46,14 @@ import {
 function getPlugin(bus: PersistentEventBus, factory: any) {
   const jsonApi = new JsonApiHapiPlugin(factory, baseUrl, {} as any);
   return new RealtimeHapiPlugin(jsonApi, bus, logger(undefined, true));
+}
+
+function getMockCommentModule() {
+  const commentModule = {} as CommentModule;
+  commentModule.getCommentCountForDeployment = async (deploymentId: number) => {
+    return 2;
+  };
+  return commentModule;
 }
 
 let persistence: any = { type: 'inmemory' };
@@ -227,9 +239,15 @@ describe('realtime-hapi-plugin', () => {
     it('is transformed correctly to StreamingDeploymentEvent', async () => {
       const branchName = 'foo-branch-name';
       const projectId = 5;
-      const mockFactory = () => ({
-        toApiDeployment: JsonApiModule.prototype.toApiDeployment,
-      });
+      const mockFactory = () => new JsonApiModule(
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        {} as any,
+        getMockCommentModule(),
+      );
+
       const eventBus = getEventBus();
       const plugin = getPlugin(eventBus, mockFactory);
 


### PR DESCRIPTION
This PR adds a `comment-count` field into json-api deployment entities.

Example:
```json
{
    "data": {
        "type": "deployments",
        "id": "530-501",
        "attributes": {
            "status": "success",
            "url": "http://deploy-master-fde804ee-530-501.127.0.0.1.xip.io:8000",
            "creator": {
                "email": "foo@bar.com",
                "name": "Foo Bar",
                "timestamp": "2016-12-05T15:13:02.750Z"
            },
            "screenshot": "http://localhost:8000/screenshot/530/501?token=5ad76732721c2538aa56a11bf613db7180a18b6ab65db07394c4248a710a4386",
            "build-status": "success",
            "extraction-status": "success",
            "screenshot-status": "success",
            "comment-count": 2
        }
    }
}
```

Note that now `toApiDeployment` now actually has to be async. The signature was already async in anticipation of this, which is nice.

