### PR TITLE
Comment activity

### DIFF
--- a/migrations/activity/migration-0002-comment-support.js
+++ b/migrations/activity/migration-0002-comment-support.js
@@ -1,0 +1,18 @@
+
+exports.up = knex => Promise.all([
+  knex.schema.table('activity', (table) => {
+    table.string('email');
+    table.string('name');
+    table.string('message');
+    table.integer('commentId');
+  }),
+]);
+
+exports.down = knex => Promise.all([
+  knex.schema.table('activity', (table) => {
+    table.dropColumn('email');
+    table.dropColumn('name');
+    table.dropColumn('message');
+    table.dropColumn('commentId');
+  }),
+]);

--- a/src/activity/types.ts
+++ b/src/activity/types.ts
@@ -6,24 +6,36 @@ import { MinardCommit } from '../shared/minard-commit';
 
 import * as moment from 'moment';
 
-export interface MinardActivity extends MinardActivityPlain {
+export interface MinardCommentActivity extends MinardActivity {
+  commentId: number;
+  name?: string;
+  email: string;
+  message: string;
+}
+
+export interface MinardDeploymentActivity extends MinardActivity {
+
+}
+
+export interface MinardActivity {
+  activityType: 'deployment' | 'comment';
   deployment: MinardDeployment;
+  id?: number;
+  timestamp: moment.Moment;
+  teamId: number;
+  projectId: number;
+  projectName: string;
+  branch: string;
   commit: MinardCommit;
+  name?: string;
+  email?: string;
+  message?: string;
+  commentId?: number;
 }
 
 export interface MinardActivityBranch {
   id: string;
   name: string;
-}
-
-export interface MinardActivityPlain {
-  id?: number;
-  timestamp: moment.Moment;
-  activityType: 'deployment';
-  teamId: number;
-  projectId: number;
-  projectName: string;
-  branch: string;
 }
 
 export const NEW_ACTIVITY = 'NEW_ACTIVITY';

--- a/src/json-api/json-api-module.ts
+++ b/src/json-api/json-api-module.ts
@@ -1,6 +1,7 @@
 
 import * as Boom from 'boom';
 import { inject, injectable } from 'inversify';
+import { isNil, omitBy } from 'lodash';
 import * as moment from 'moment';
 
 import { toGitlabTimestamp, toMoment } from '../shared/time-conversion';
@@ -213,7 +214,8 @@ export class JsonApiModule {
     delete deployment.commitHash;
     delete deployment.teamId;
     const timestamp = toGitlabTimestamp(activity.timestamp);
-    return {
+
+    const ret: ApiActivity = {
       id: `${activity.projectId}-${activity.deployment.id}`,
       type: 'activity',
       branch,
@@ -222,7 +224,11 @@ export class JsonApiModule {
       timestamp,
       activityType: activity.activityType,
       deployment,
+      message: activity.message,
+      name: activity.name,
+      email: activity.email,
     };
+    return omitBy(ret, isNil) as ApiActivity;
   }
 
   public async toApiCommit(

--- a/src/json-api/serialization-spec.ts
+++ b/src/json-api/serialization-spec.ts
@@ -130,6 +130,20 @@ const exampleActivity = {
   timestamp: exampleDeploymentOne.creator!.timestamp,
 } as ApiActivity;
 
+const exampleCommentActivity = {
+  type: 'activity',
+  id: 'dasfsa',
+  project: { id: '3', name: 'foo' },
+  branch: { id: '3-master', name: 'master' },
+  activityType: 'comment',
+  deployment: exampleDeploymentOne,
+  commit: exampleCommitOne,
+  timestamp: exampleDeploymentOne.creator!.timestamp,
+  message: 'foo msg',
+  name: 'foo name',
+  email: 'foo email',
+} as ApiActivity;
+
 const exampleComment: ApiComment = {
   id: 5,
   project: 6,
@@ -352,8 +366,7 @@ describe('json-api serialization', () => {
   });
 
   describe('activityToJsonApi()', () => {
-    it('should work with a single activity', () => {
-      const activity = exampleActivity as ApiActivity;
+    function testActivity(activity: ApiActivity) {
       const converted = serializeApiEntity('activity', activity, apiBaseUrl) as JsonApiResponse;
       const data = converted.data as JsonApiEntity;
       expect(data).to.exist;
@@ -377,6 +390,21 @@ describe('json-api serialization', () => {
       // do not include extra stuff
       expect(converted.included).to.not.exist;
       expect(data.relationships).to.not.exist;
+      return data;
+    }
+
+    it('should work with a deployment activity', () => {
+      const activity = exampleActivity as ApiActivity;
+      const data = testActivity(activity);
+      expect(data.attributes.email).to.be.undefined;
+    });
+
+    it('should work with a comment activity', () => {
+      const activity = exampleCommentActivity as ApiActivity;
+      const data = testActivity(activity);
+      expect(data.attributes.email).to.equal(activity.email);
+      expect(data.attributes.name).to.equal(activity.name);
+      expect(data.attributes.message).to.equal(activity.message);
     });
   });
 

--- a/src/json-api/serialization.ts
+++ b/src/json-api/serialization.ts
@@ -1,5 +1,5 @@
-const Serializer = require('jsonapi-serializer').Serializer; // tslint:disable-line
 
+const Serializer = require('jsonapi-serializer').Serializer; // tslint:disable-line
 const deepcopy = require('deepcopy');
 
 import {
@@ -113,7 +113,16 @@ export const projectSerialization = (apiBaseUrl: string) => {
 };
 
 export const activitySerialization = {
-  attributes: ['timestamp', 'activityType', 'deployment', 'project', 'branch', 'commit'],
+  attributes: [
+    'timestamp',
+    'activityType',
+    'deployment',
+    'project',
+    'branch',
+    'commit',
+    'name',
+    'email',
+    'message'],
   ref: standardIdRef,
   included: true,
 };

--- a/src/json-api/types.ts
+++ b/src/json-api/types.ts
@@ -94,13 +94,16 @@ export interface ApiActivityCommit extends MinardCommit {
 
 export interface ApiActivity {
   type: 'activity';
-  activityType: string;
+  activityType: 'comment' | 'deployment';
   id: string;
   timestamp: string;
   deployment: ApiDeployment;
   project: ApiActivityProject;
   branch: ApiActivityBranch;
   commit: ApiActivityCommit;
+  name?: string;
+  email?: string;
+  message?: string;
 }
 
 export interface ApiComment {


### PR DESCRIPTION
Based on https://github.com/lucified/minard-backend/pull/132

This PR adds support for creating comment activity for new comments.

## API example 
Comment activity looks as follows:
```json
        {
            "type": "activities",
            "id": "534-503",
            "attributes": {
                "timestamp": "2016-12-06T14:33:40.650Z",
                "activity-type": "comment",
                "deployment": {
                    "id": "534-503",
                    "status": "success",
                    "creator": {
                        "email": "foo@bar.com",
                        "name": "Foo Bar",
                        "timestamp": "2016-12-06T14:33:09.146Z"
                    },
                    "created-at": "2016-12-06T14:33:09.146Z",
                    "project-id": 534,
                    "finished-at": "2016-12-06T14:33:35.030Z",
                    "build-status": "success",
                    "project-name": "integration-test-project",
                    "extraction-status": "success",
                    "screenshot-status": "success",
                    "url": "http://deploy-master-ba2511e5-534-503.127.0.0.1.xip.io:8000",
                    "screenshot": "http://localhost:8000/screenshot/534/503?token=70088f7b521abc9231ccf0a96201776e148516630e39525d0b3d68dbf33ab211"
                },
                "project": {
                    "id": "534",
                    "name": "integration-test-project"
                },
                "branch": {
                    "id": "534-master",
                    "name": "master"
                },
                "commit": {
                    "id": "534-ba2511e5f76b66b18a0b89bd344c44343959036c",
                    "author": {
                        "name": "Foo Bar",
                        "email": "foo@bar.com",
                        "timestamp": "2016-12-06T16:32:56.000+02:00"
                    },
                    "message": "Improve colors and styling\n",
                    "short-id": "ba2511e5",
                    "committer": {
                        "name": "Foo Bar",
                        "email": "foo@bar.com",
                        "timestamp": "2016-12-06T16:32:56.000+02:00"
                    },
                    "parent-ids": [],
                    "hash": "ba2511e5f76b66b18a0b89bd344c44343959036c"
                },
                "name": "foo",
                "email": "foo@fooman.com",
                "message": "foo message"
            }
        }
```

These are streamed via the realtime streaming api as any other activity.

## Implementation notes:
I chose to store the comment's new attributes `name`, `email`, `message` in regular database columns, instead of wrapping them inside a `comment` json object. After having tried both ways in this project, I feel that this way is simply easier overall.

## Other notes:
I also removed some extraneous fields from the deployment objects within activity.

## Warning
This PR will most likely break the UI, as it does not know how to deal with this new type of activity. We should not merge this to master, before we have support for this in the UI.
