### PR TITLE
Allow name to be an empty string when creating comments

### DIFF
--- a/src/json-api/json-api-hapi-plugin.ts
+++ b/src/json-api/json-api-hapi-plugin.ts
@@ -606,7 +606,7 @@ export class JsonApiHapiPlugin {
       throw Boom.badRequest('Invalid deployment id');
     }
     const comment = await this.factory().addComment(
-        parsed.deploymentId, email, message, name === '' ? undefined : name);
+        parsed.deploymentId, email, message, name || undefined);
     return reply(this.serializeApiEntity('comment', comment))
       .created(`/api/comments/${comment.id}`);
   }


### PR DESCRIPTION
This PR makes the backend allow empty strings for `name` when creating comments.

Empty strings are now handled equally to `name` being undefined.

