### PR TITLE
Remove PING from the event list

### DIFF
--- a/docs/api/api-streaming.md
+++ b/docs/api/api-streaming.md
@@ -316,8 +316,3 @@ repo-url|string|New git repository URL for edited project
     "repo-url": "http://localhost:10080/test/integration-test-project.git"
 }
 ```
-
-### `PING`
-
-Occurs every two seconds if there are no other events
-in the event stream.


### PR DESCRIPTION
Including `PING` in the list a bit misleading since it's not an event type but a comment. Also, it occurs every 20 seconds whether there's other activity or not.