### PR TITLE
Raw deployment auth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:7.4-alpine
+FROM node:7.5-alpine
 
 WORKDIR /code
 

--- a/Dockerfile-production
+++ b/Dockerfile-production
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:6.9
+FROM node:7.5-alpine
 
 WORKDIR /code
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,10 +194,11 @@ services:
       - REDIS_PORT=6379
       - SYSTEMHOOK_BASEURL=http://charles:8000
       - EXTERNAL_BASEURL=http://localhost:8000
-      - SCREENSHOT_URL_PATTERN=http://deploy-%s.charles.internal:8000
+      - SCREENSHOT_URL_PATTERN=http://deploy-%s.charles.internal:8001
       - SCREENSHOTTER_BASEURL=http://screenshotter
       - DEPLOYMENT_URL_PATTERN=http://deploy-%s.127.0.0.1.xip.io:8000
       - EXTERNAL_GIT_BASEURL=http://localhost:10080
       - GITLAB_ROOT_PASSWORD=12345678
       - SENTRY_DSN=$SENTRY_DSN
+      - INTEGRATION_TEST=$INTEGRATION_TEST
       - EXIT_DELAY=0

--- a/src/authentication/authentication-hapi-plugin-spec.ts
+++ b/src/authentication/authentication-hapi-plugin-spec.ts
@@ -83,7 +83,7 @@ describe('authentication-hapi-plugin', () => {
       fetchMock.mock(/\/users/, [{
         id: 1,
       }]);
-      fetchMock.mock(/\/groups/, [{
+      fetchMock.mock(/\/groups\?/, [{
         id: 1,
         name: 'fooGroup',
       }]);
@@ -110,7 +110,7 @@ describe('authentication-hapi-plugin', () => {
       const adminTeamName = get<string>(adminTeamNameInjectSymbol);
 
       fetchMock.restore();
-      fetchMock.mock(/\/groups/, [{
+      fetchMock.mock(/\/groups\?/, [{
         id: 1,
         name: adminTeamName + '1',
       }]);
@@ -135,7 +135,7 @@ describe('authentication-hapi-plugin', () => {
       const db = await getDb();
       const token = await generateAndSaveTeamToken(teamId, db);
       fetchMock.restore();
-      fetchMock.mock(/\/groups/, [{
+      fetchMock.mock(/\/groups\?/, [{
         id: 1,
         name: adminTeamName,
       }]);
@@ -163,7 +163,7 @@ describe('authentication-hapi-plugin', () => {
       const db = await getDb();
       const token = await generateAndSaveTeamToken(teamId, db);
       fetchMock.restore();
-      fetchMock.mock(/\/groups/, [{
+      fetchMock.mock(/\/groups\?/, [{
         id:  teamId,
         name: teamName,
       }]);
@@ -191,7 +191,7 @@ describe('authentication-hapi-plugin', () => {
       const adminTeamName = get<string>(adminTeamNameInjectSymbol);
 
       fetchMock.restore();
-      fetchMock.mock(/\/groups/, [{
+      fetchMock.mock(/\/groups\?/, [{
         id: 1,
         name: adminTeamName,
       }]);
@@ -220,7 +220,7 @@ describe('authentication-hapi-plugin', () => {
       const adminTeamName = get<string>(adminTeamNameInjectSymbol);
 
       fetchMock.restore();
-      fetchMock.mock(/\/groups/, [{
+      fetchMock.mock(/\/groups\?/, [{
         id: 1,
         name: adminTeamName,
       }]);
@@ -249,7 +249,7 @@ describe('authentication-hapi-plugin', () => {
       fetchMock.mock(/\/users/, [{
         id: 1,
       }]);
-      fetchMock.mock(/\/groups/, [{
+      fetchMock.mock(/\/groups\?/, [{
         id: 1,
         name: 'fooGroup',
       }]);
@@ -315,10 +315,10 @@ describe('authentication-hapi-plugin', () => {
       fetchMock.mock(/\/users/, [{
         id: 1,
       }]);
-      fetchMock.mock(/\/groups/, [{
+      fetchMock.mock(/\/groups\/1/, {
         id: validTeamToken.teamId + 1,
         name: 'fooGroup',
-      }]);
+      });
 
       // Act
       const response = await server.inject({
@@ -349,10 +349,10 @@ describe('authentication-hapi-plugin', () => {
       fetchMock.mock(/\/users/, [{
         id: 1,
       }]);
-      fetchMock.mock(/\/groups/, [{
+      fetchMock.mock(/\/groups\/1/, {
         id: validTeamToken.teamId,
         name: 'fooGroup',
-      }]);
+      });
 
       // Act
       const response = await server.inject({
@@ -383,7 +383,7 @@ describe('authentication-hapi-plugin', () => {
       fetchMock.mock(/\/users/, [{
         id: 1,
       }]);
-      fetchMock.mock(/\/groups/, [{
+      fetchMock.mock(/\/groups\?/, [{
         id: 1,
         name: 'fooGroup',
       }]);

--- a/src/authentication/authentication-hapi-plugin-spec.ts
+++ b/src/authentication/authentication-hapi-plugin-spec.ts
@@ -399,11 +399,11 @@ describe('authentication-hapi-plugin', () => {
       const token = cookie.replace(/^token=([^;]+).*$/, '$1');
       expect(token).to.eq(validAccessToken);
     });
-    it('should not accept an invalid externalBaseUrl', () => {
+    it('should not accept an invalid url', () => {
       const settings = () => accessTokenCookieSettings('htttp://foo.bar');
       expect(settings).to.throw();
     });
-    it('should have isSecure flag set depending on externalBaseUrl', () => {
+    it('should have isSecure flag set depending on url', () => {
       const settings1 = accessTokenCookieSettings('http://foo.bar');
       const settings2 = accessTokenCookieSettings('https://foo.bar');
 
@@ -411,9 +411,19 @@ describe('authentication-hapi-plugin', () => {
       expect(settings2.isSecure).to.be.true;
 
     });
-    // it('should have a domain parsed from externalBaseUrl and prepended with a dot', () => {
-    //   const settings = accessTokenCookieSettings('http://foo.bar:8080/baz');
-    //   expect(settings.domain).to.eq('.foo.bar');
-    // });
+    it('should have the domain parsed from url and prepended with a dot', () => {
+      const settings = accessTokenCookieSettings('http://foo.bar:8080');
+      expect(settings.domain).to.eq('.foo.bar');
+      expect(settings.path).to.eq('/');
+    });
+    it('should have the path parsed from url', () => {
+      const settings = accessTokenCookieSettings('http://foo.bar:8080/baz');
+      expect(settings.path).to.eq('/baz');
+    });
+    it('should accept a non-url domain', () => {
+      const settings = accessTokenCookieSettings('.foo.bar');
+      expect(settings.domain).to.eq('.foo.bar');
+      expect(settings.path).to.eq('/');
+    });
   });
 });

--- a/src/authentication/authentication-hapi-plugin-spec.ts
+++ b/src/authentication/authentication-hapi-plugin-spec.ts
@@ -284,10 +284,10 @@ describe('authentication-hapi-plugin', () => {
       fetchMock.mock(/\/users/, [{
         id: 1,
       }]);
-      fetchMock.mock(/\/groups/, [{
+      fetchMock.mock(/\/groups\/1/, {
         id: validTeamToken.teamId,
         name: 'fooGroup',
-      }]);
+      });
 
       // Act
       const response = await server.inject({

--- a/src/authentication/authentication-hapi-plugin-spec.ts
+++ b/src/authentication/authentication-hapi-plugin-spec.ts
@@ -411,9 +411,9 @@ describe('authentication-hapi-plugin', () => {
       expect(settings2.isSecure).to.be.true;
 
     });
-    it('should have a domain parsed from externalBaseUrl and prepended with a dot', () => {
-      const settings = accessTokenCookieSettings('http://foo.bar:8080/baz');
-      expect(settings.domain).to.eq('.foo.bar');
-    });
+    // it('should have a domain parsed from externalBaseUrl and prepended with a dot', () => {
+    //   const settings = accessTokenCookieSettings('http://foo.bar:8080/baz');
+    //   expect(settings.domain).to.eq('.foo.bar');
+    // });
   });
 });

--- a/src/authentication/authentication-hapi-plugin.ts
+++ b/src/authentication/authentication-hapi-plugin.ts
@@ -346,10 +346,12 @@ export function accessTokenCookieSettings(
   path = '/',
 ): Hapi.ICookieSettings {
   const isSecure = externalBaseUrl.match(/^https/) !== null;
-  const domain = externalBaseUrl.replace(/^https?:\/\/([^/:]+).+$/, '.$1');
-  if (domain === externalBaseUrl) {
+  const parsedDomain = externalBaseUrl.replace(/^https?:\/\/([^/:]+).+$/, '.$1');
+  if (parsedDomain === externalBaseUrl) {
     throw new Error(`Invalid externalBaseUrl`);
   }
+  // TODO: make this an environment variable (or something)
+  const domain = parsedDomain.indexOf('localhost') !== -1 ? '.minard.io' : parsedDomain;
   return {
     ttl,
     isSecure,

--- a/src/authentication/authentication-hapi-plugin.ts
+++ b/src/authentication/authentication-hapi-plugin.ts
@@ -351,7 +351,7 @@ export function accessTokenCookieSettings(
     throw new Error(`Invalid externalBaseUrl`);
   }
   // TODO: make this an environment variable (or something)
-  const domain = parsedDomain.indexOf('localhost') !== -1 ? '.minard.io' : parsedDomain;
+  const domain = parsedDomain.indexOf('localhost') !== -1 ? parsedDomain : '.minard.io';
   return {
     ttl,
     isSecure,

--- a/src/authentication/authentication-hapi-plugin.ts
+++ b/src/authentication/authentication-hapi-plugin.ts
@@ -279,7 +279,7 @@ class AuthenticationHapiPlugin extends HapiPlugin {
       ...this.hapiOptions,
       validateFunc: this.validateAdmin.bind(this),
     });
-    const ttl = 365 * 24 * 3600 * 1000;
+    const ttl = 365 * 24 * 3600 * 1000; // ~year in ms
     server.state('token', accessTokenCookieSettings(this.authCookieDomain, ttl));
   }
 }

--- a/src/authentication/authentication-hapi-plugin.ts
+++ b/src/authentication/authentication-hapi-plugin.ts
@@ -191,7 +191,7 @@ class AuthenticationHapiPlugin extends HapiPlugin {
       }).code(201); // created
     } catch (error) {
       // TODO: Remove boom message from error message?
-      const message = `Unable to sign up user ${email}: ${error.isBoom && error.output.payload.message}`;
+      const message = `Unable to sign up user ${email}: ${error.isBoom && error.output.payload.message || ''}`;
       this.logger.error(message, {
         error,
         credentials,

--- a/src/authentication/authentication-hapi-plugin.ts
+++ b/src/authentication/authentication-hapi-plugin.ts
@@ -168,6 +168,9 @@ class AuthenticationHapiPlugin extends HapiPlugin {
         throw new Error(`Invalid email ${email}`);
       }
       const teamToken = credentials[teamTokenClaimKey]!;
+      if (!teamToken) {
+        throw new Error('Missing team token');
+      }
       const teamId = await getTeamIdWithToken(teamToken, this.db);
       const team = await this.gitlab.getGroup(teamId);
       const password = generatePassword();

--- a/src/authentication/authentication-hapi-plugin.ts
+++ b/src/authentication/authentication-hapi-plugin.ts
@@ -190,7 +190,8 @@ class AuthenticationHapiPlugin extends HapiPlugin {
         password,
       }).code(201); // created
     } catch (error) {
-      const message = `Problems on signup for user ${email}`;
+      // TODO: Remove boom message from error message?
+      const message = `Unable to sign up user ${email}: ${error.isBoom && error.output.payload.message}`;
       this.logger.error(message, {
         error,
         credentials,

--- a/src/authentication/authentication-hapi-plugin.ts
+++ b/src/authentication/authentication-hapi-plugin.ts
@@ -181,6 +181,7 @@ class AuthenticationHapiPlugin extends HapiPlugin {
         idp,
       );
       await this.gitlab.addUserToGroup(user.id, teamId);
+      this.setAuthCookie(request, reply);
       return reply({
         team,
         password,

--- a/src/authentication/types.ts
+++ b/src/authentication/types.ts
@@ -1,6 +1,7 @@
 export const authServerBaseUrlInjectSymbol = Symbol('auth-server-base-url');
 export const gitlabRootPasswordInjectSymbol = Symbol('gitlab-root-password');
 export const jwtOptionsInjectSymbol = Symbol('token-verify-options');
+export const authCookieDomainInjectSymbol = Symbol('auth-cookie-domain');
 
 export const teamTokenClaimKey = 'https://minard.io/team_token';
 

--- a/src/config/config-development.ts
+++ b/src/config/config-development.ts
@@ -1,6 +1,9 @@
 import { Container } from 'inversify';
+
+import { jwtOptionsInjectSymbol } from '../authentication';
 import { goodOptionsInjectSymbol } from '../server';
 import productionConfig from './config-production';
+import { getJwtOptions } from './config-test';
 import { FilterStream } from './utils';
 
 function requestFilter(data: any) {
@@ -38,4 +41,8 @@ const goodOptions = {
 export default (kernel: Container) => {
   productionConfig(kernel);
   kernel.rebind(goodOptionsInjectSymbol).toConstantValue(goodOptions);
+  if (process.env.INTEGRATION_TEST === '1') {
+    console.log('** INTEGRATION TEST MODE **');
+    kernel.rebind(jwtOptionsInjectSymbol).toConstantValue(getJwtOptions());
+  }
 };

--- a/src/config/config-production.ts
+++ b/src/config/config-production.ts
@@ -51,6 +51,7 @@ import {
 } from '../shared/types';
 
 import {
+  authCookieDomainInjectSymbol,
   authServerBaseUrlInjectSymbol,
   gitlabRootPasswordInjectSymbol,
   jwtOptionsInjectSymbol,
@@ -247,6 +248,7 @@ const cache = cacheManager.caching({
 const GITLAB_ROOT_PASSWORD = env.GITLAB_ROOT_PASSWORD || '12345678';
 const AUTH_SERVER_BASE_URL = env.AUTH_SERVER_BASE_URL || 'https://lucify-dev.eu.auth0.com';
 const AUTH_AUDIENCE = env.AUTH_AUDIENCE || EXTERNAL_BASEURL;
+const AUTH_COOKIE_DOMAIN = env.AUTH_COOKIE_DOMAIN || AUTH_AUDIENCE;
 
 const jwtOptions: auth.JWTStrategyOptions = {
   // Get the complete decoded token, because we need info from the header (the kid)
@@ -319,6 +321,7 @@ export default (kernel: Container) => {
   kernel.bind(exitDelayInjectSymbol).toConstantValue(EXIT_DELAY);
   kernel.bind(tokenSecretInjectSymbol).toConstantValue(TOKEN_SECRET);
   kernel.bind(authServerBaseUrlInjectSymbol).toConstantValue(AUTH_SERVER_BASE_URL);
+  kernel.bind(authCookieDomainInjectSymbol).toConstantValue(AUTH_COOKIE_DOMAIN);
   kernel.bind(jwtOptionsInjectSymbol).toConstantValue(jwtOptions);
   kernel.bind(adminTeamNameInjectSymbol).toConstantValue(ADMIN_TEAM_NAME);
 };

--- a/src/config/config-production.ts
+++ b/src/config/config-production.ts
@@ -122,7 +122,7 @@ const env = process.env;
 
 // Host and port in which we are listening locally
 const HOST = env.HOST || '0.0.0.0';
-const PORT = env.PORT ? parseInt(env.PORT, 10) : 8080;
+const PORT = env.PORT ? parseInt(env.PORT, 10) : 8000;
 
 // Host and port from which charles can reach GitLab
 const GITLAB_HOST = env.GITLAB_HOST || 'localhost';

--- a/src/config/config-test.ts
+++ b/src/config/config-test.ts
@@ -23,12 +23,6 @@ const getClient = () => {
   return new GitlabClient('gitlab', fetchMock.fetchMock, new MockAuthModule() as AuthenticationModule, logger, false);
 };
 
-const charlesKnex = Knex({
-  client: 'sqlite3',
-  connection: { filename: ':memory:' },
-  useNullAsDefault: true,
-});
-
 // Access token parameters
 const env = process.env;
 const PORT = env.PORT ? parseInt(env.PORT, 10) : 8000;
@@ -54,7 +48,7 @@ export function getJwtOptions() {
     verifyOptions,
     // Validate the audience, issuer, algorithm and expiration.
     errorFunc: (context: any) => {
-      console.dir({...verifyOptions, secretKey}, {colors: true});
+      console.dir({ ...verifyOptions, secretKey }, { colors: true });
       return context;
     },
   };
@@ -82,6 +76,11 @@ export default (kernel: Container) => {
   kernel.rebind(fetchInjectSymbol).toConstantValue(fetchMock.fetchMock);
   kernel.rebind(goodOptionsInjectSymbol).toConstantValue({});
   kernel.rebind(GitlabClient.injectSymbol).toConstantValue(getClient());
+  const charlesKnex = Knex({
+    client: 'sqlite3',
+    connection: { filename: ':memory:' },
+    useNullAsDefault: true,
+  });
   kernel.rebind(charlesKnexInjectSymbol).toConstantValue(charlesKnex);
   kernel.rebind(loggerInjectSymbol).toConstantValue(logger);
   kernel.rebind(jwtOptionsInjectSymbol).toConstantValue(getJwtOptions());

--- a/src/config/config-test.ts
+++ b/src/config/config-test.ts
@@ -1,4 +1,3 @@
-// import * as auth from 'hapi-auth-jwt2';
 import { Container } from 'inversify';
 import { sign } from 'jsonwebtoken';
 import * as Knex from 'knex';
@@ -75,7 +74,6 @@ export function getAccessToken(sub: string, teamToken?: string, email?: string) 
   if (email) {
     payload = { ...payload, email };
   }
-  console.log(payload);
   return sign(payload, secretKey);
 }
 

--- a/src/config/config-test.ts
+++ b/src/config/config-test.ts
@@ -2,7 +2,12 @@ import { Container } from 'inversify';
 import { sign } from 'jsonwebtoken';
 import * as Knex from 'knex';
 
-import { AccessToken, jwtOptionsInjectSymbol, teamTokenClaimKey } from '../authentication';
+import {
+  AccessToken,
+  authCookieDomainInjectSymbol,
+  jwtOptionsInjectSymbol,
+  teamTokenClaimKey,
+} from '../authentication';
 import AuthenticationModule from '../authentication/authentication-module';
 import { goodOptionsInjectSymbol } from '../server';
 import { fetchMock } from '../shared/fetch';
@@ -28,6 +33,7 @@ const env = process.env;
 const PORT = env.PORT ? parseInt(env.PORT, 10) : 8000;
 const EXTERNAL_BASEURL = env.EXTERNAL_BASEURL || `http://localhost:${PORT}`;
 const AUTH_AUDIENCE = env.AUTH_AUDIENCE || EXTERNAL_BASEURL;
+const AUTH_COOKIE_DOMAIN = env.AUTH_COOKIE_DOMAIN || AUTH_AUDIENCE;
 
 export const issuer = 'https://issuer.foo.com';
 export const secretKey = 'shhhhhhh';
@@ -84,4 +90,5 @@ export default (kernel: Container) => {
   kernel.rebind(charlesKnexInjectSymbol).toConstantValue(charlesKnex);
   kernel.rebind(loggerInjectSymbol).toConstantValue(logger);
   kernel.rebind(jwtOptionsInjectSymbol).toConstantValue(getJwtOptions());
+  kernel.rebind(authCookieDomainInjectSymbol).toConstantValue(AUTH_COOKIE_DOMAIN);
 };

--- a/src/deployment/deployment-hapi-plugin.ts
+++ b/src/deployment/deployment-hapi-plugin.ts
@@ -106,15 +106,15 @@ class DeploymentHapiPlugin {
 
   private deploymentRoutes(auth = true) {
     const directoryHandler = {
-        directory: {
-          path: this.serveDirectory.bind(this),
-          index: true,
-          listing: true,
-          showHidden: false,
-          redirectToSlash: false,
-          lookupCompressed: false,
-        },
-      };
+      directory: {
+        path: this.serveDirectory.bind(this),
+        index: true,
+        listing: true,
+        showHidden: false,
+        redirectToSlash: false,
+        lookupCompressed: false,
+      },
+    };
     return [{
       method: 'GET',
       path: '/deployment-favicon',
@@ -150,7 +150,7 @@ class DeploymentHapiPlugin {
       },
     }].map((route: any) => {
       if (!auth) {
-        route.config = {...(route.config || {}), auth: false};
+        route.config = { ...(route.config || {}), auth: false };
       }
       return route;
     });
@@ -165,7 +165,7 @@ class DeploymentHapiPlugin {
   }
 
   private async getGitlabYmlRequestHandler(request: Hapi.Request, reply: Hapi.IReply) {
-    const { projectId, ref, sha } = (<any> request.params);
+    const { projectId, ref, sha } = request.params as any;
     return reply(this.deploymentModule.getGitlabYml(projectId, ref, sha))
       .header('content-type', 'text/plain');
   }
@@ -179,7 +179,7 @@ class DeploymentHapiPlugin {
   }
 
   private serveDirectory(request: Hapi.Request) {
-    const pre = <any> request.pre;
+    const pre = request.pre as any;
     const projectId = pre.key.projectId;
     const deploymentId = pre.key.deploymentId;
     return this.distPath(projectId, deploymentId);
@@ -211,7 +211,7 @@ class DeploymentHapiPlugin {
   }
 
   private async preCheck(request: Hapi.Request, reply: Hapi.IReply) {
-    const pre = <any> request.pre;
+    const pre = request.pre as any;
     const shortId = pre ? pre.key.shortId : request.paramsArray[0];
     const projectId = pre ? pre.key.projectId : parseInt(request.paramsArray[1], 10);
     const deploymentId = pre ? pre.key.deploymentId : parseInt(request.paramsArray[2], 10);

--- a/src/deployment/deployment-hapi-plugin.ts
+++ b/src/deployment/deployment-hapi-plugin.ts
@@ -83,7 +83,6 @@ class DeploymentHapiPlugin {
         },
       },
       config: {
-        auth: false,
         pre: [
           { method: this.parseHost.bind(this), assign: 'key' },
           { method: this.preCheck.bind(this) },

--- a/src/integration-test/system-integration-tests.ts
+++ b/src/integration-test/system-integration-tests.ts
@@ -11,6 +11,7 @@ import { spawn } from 'child_process';
 import { keys } from 'lodash';
 import 'reflect-metadata';
 
+import { generateTeamToken } from '../authentication/team-token';
 import { getAccessToken } from '../config/config-test';
 import { JsonApiEntity, JsonApiResponse } from '../json-api';
 import { fetch as originalFetch, RequestInit, Response } from '../shared/fetch';
@@ -56,7 +57,7 @@ async function fetchWithRetry(url: string, options?: RequestInit, retryCount = 5
   throw Error(`Fetch failed ${retryCount} times for url ${url}`);
 }
 
-const accessToken = getAccessToken('idp|232342', '1111222233334444', 'foo@bar.com');
+const accessToken = getAccessToken('idp|232342', generateTeamToken(), 'foo@bar.com');
 
 async function fetch(url: string, options?: RequestInit): Promise<Response> {
   let _options: RequestInit = {

--- a/src/server/hapi.ts
+++ b/src/server/hapi.ts
@@ -11,6 +11,9 @@ declare module 'hapi' {
   interface IRouteHandlerConfig {
     async?: AsyncHandler;
   }
+  interface ICookieSettings {
+    isSameSite: false | 'Strict' | 'Lax';
+  }
 }
 
 type AsyncHandler = (request: Request, reply: IReply ) => Promise<any>;

--- a/src/shared/gitlab-client-spec.ts
+++ b/src/shared/gitlab-client-spec.ts
@@ -102,6 +102,183 @@ describe('gitlab-client', () => {
     });
   });
 
+  describe('getGroup', () => {
+    it('returns a single group', async () => {
+      // Arrange
+      const gitlab = getClient();
+      fetchMock.restore();
+      const id = 4;
+      fetchMock.mock(/\/groups\/4/, {
+        id,
+        name: 'Twitter',
+        path: 'twitter',
+        description: 'Aliquid qui quis dignissimos distinctio ut commodi voluptas est.',
+        visibility_level: 20,
+        avatar_url: null,
+        web_url: 'https://gitlab.example.com/groups/twitter',
+        request_access_enabled: false,
+        full_name: 'Twitter',
+        full_path: 'twitter',
+        parent_id: null,
+        projects: [
+          {
+            id: 7,
+            description: 'Voluptas veniam qui et beatae voluptas doloremque explicabo facilis.',
+            default_branch: 'master',
+            tag_list: [],
+            public: true,
+            archived: false,
+            visibility_level: 20,
+            ssh_url_to_repo: 'git@gitlab.example.com:twitter/typeahead-js.git',
+            http_url_to_repo: 'https://gitlab.example.com/twitter/typeahead-js.git',
+            web_url: 'https://gitlab.example.com/twitter/typeahead-js',
+            name: 'Typeahead.Js',
+            name_with_namespace: 'Twitter / Typeahead.Js',
+            path: 'typeahead-js',
+            path_with_namespace: 'twitter/typeahead-js',
+            issues_enabled: true,
+            merge_requests_enabled: true,
+            wiki_enabled: true,
+            builds_enabled: true,
+            snippets_enabled: false,
+            container_registry_enabled: true,
+            created_at: '2016-06-17T07:47:25.578Z',
+            last_activity_at: '2016-06-17T07:47:25.881Z',
+            shared_runners_enabled: true,
+            creator_id: 1,
+            namespace: {
+              id: 4,
+              name: 'Twitter',
+              path: 'twitter',
+              kind: 'group',
+            },
+            avatar_url: null,
+            star_count: 0,
+            forks_count: 0,
+            open_issues_count: 3,
+            public_builds: true,
+            shared_with_groups: [],
+            request_access_enabled: false,
+          },
+          {
+            id: 6,
+            description: 'Aspernatur omnis repudiandae qui voluptatibus eaque.',
+            default_branch: 'master',
+            tag_list: [],
+            public: false,
+            archived: false,
+            visibility_level: 10,
+            ssh_url_to_repo: 'git@gitlab.example.com:twitter/flight.git',
+            http_url_to_repo: 'https://gitlab.example.com/twitter/flight.git',
+            web_url: 'https://gitlab.example.com/twitter/flight',
+            name: 'Flight',
+            name_with_namespace: 'Twitter / Flight',
+            path: 'flight',
+            path_with_namespace: 'twitter/flight',
+            issues_enabled: true,
+            merge_requests_enabled: true,
+            wiki_enabled: true,
+            builds_enabled: true,
+            snippets_enabled: false,
+            container_registry_enabled: true,
+            created_at: '2016-06-17T07:47:24.661Z',
+            last_activity_at: '2016-06-17T07:47:24.838Z',
+            shared_runners_enabled: true,
+            creator_id: 1,
+            namespace: {
+              id: 4,
+              name: 'Twitter',
+              path: 'twitter',
+              kind: 'group',
+            },
+            avatar_url: null,
+            star_count: 0,
+            forks_count: 0,
+            open_issues_count: 8,
+            public_builds: true,
+            shared_with_groups: [],
+            request_access_enabled: false,
+          },
+        ],
+        shared_projects: [
+          {
+            id: 8,
+            description: 'Velit eveniet provident fugiat saepe eligendi autem.',
+            default_branch: 'master',
+            tag_list: [],
+            public: false,
+            archived: false,
+            visibility_level: 0,
+            ssh_url_to_repo: 'git@gitlab.example.com:h5bp/html5-boilerplate.git',
+            http_url_to_repo: 'https://gitlab.example.com/h5bp/html5-boilerplate.git',
+            web_url: 'https://gitlab.example.com/h5bp/html5-boilerplate',
+            name: 'Html5 Boilerplate',
+            name_with_namespace: 'H5bp / Html5 Boilerplate',
+            path: 'html5-boilerplate',
+            path_with_namespace: 'h5bp/html5-boilerplate',
+            issues_enabled: true,
+            merge_requests_enabled: true,
+            wiki_enabled: true,
+            builds_enabled: true,
+            snippets_enabled: false,
+            container_registry_enabled: true,
+            created_at: '2016-06-17T07:47:27.089Z',
+            last_activity_at: '2016-06-17T07:47:27.310Z',
+            shared_runners_enabled: true,
+            creator_id: 1,
+            namespace: {
+              id: 5,
+              name: 'H5bp',
+              path: 'h5bp',
+              kind: 'group',
+            },
+            avatar_url: null,
+            star_count: 0,
+            forks_count: 0,
+            open_issues_count: 4,
+            public_builds: true,
+            shared_with_groups: [
+              {
+                group_id: 4,
+                group_name: 'Twitter',
+                group_access_level: 30,
+              },
+              {
+                group_id: 3,
+                group_name: 'Gitlab Org',
+                group_access_level: 10,
+              },
+            ],
+          },
+        ],
+      });
+
+      // Act
+      const response = await gitlab.getGroup(id);
+
+      // Assert
+      expect(response.id).to.equal(4);
+    });
+
+    it('throws when not found', async () => {
+      // Arrange
+      const gitlab = getClient();
+      fetchMock.restore();
+      const id = 100;
+      fetchMock.mock(/\/teams\/100/, {});
+
+      // Act
+      try {
+        await gitlab.getGroup(id);
+      } catch (err) {
+        // Assert
+        expect(err).to.exist;
+        return;
+      }
+      expect.fail('Didn\'t throw');
+    });
+  });
+
   describe('getUserByEmail', () => {
     it('returns a single user', async () => {
       // Arrange

--- a/src/shared/gitlab-client.ts
+++ b/src/shared/gitlab-client.ts
@@ -231,14 +231,11 @@ export class GitlabClient {
   }
 
   public async getGroup(groupId: number) {
-    const groups = await this.fetchJson<Group[]>(`groups/${groupId}`, true);
-    if (!groups.length) {
-      throw Boom.notFound(`No groups found with id '${groupId}'`);
+    const group = await this.fetchJson<Group>(`groups/${groupId}`, true);
+    if (!group) {
+      throw Boom.notFound(`No group found with id '${groupId}'`);
     }
-    if (groups.length > 1) {
-      throw Boom.badImplementation(`Multiple groups found with id '${groupId}'`);
-    }
-    return groups[0];
+    return group;
   }
 
   public async getUserGroups(userIdOrName: number | string) {

--- a/src/shared/gitlab-client.ts
+++ b/src/shared/gitlab-client.ts
@@ -232,7 +232,7 @@ export class GitlabClient {
 
   public async getGroup(groupId: number) {
     const group = await this.fetchJson<Group>(`groups/${groupId}`, true);
-    if (!group) {
+    if (!group || !group.id) {
       throw Boom.notFound(`No group found with id '${groupId}'`);
     }
     return group;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,6 @@
     "pretty": true,
     "noImplicitReturns": true,
     "noEmitOnError": false, // still transpiles with type errors
-    "baseUrl": "./typings",
-    "skipLibCheck": true // TODO: remove once https://github.com/DefinitelyTyped/DefinitelyTyped/issues/14324 resolved
+    "baseUrl": "./typings"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "pretty": true,
     "noImplicitReturns": true,
     "noEmitOnError": false, // still transpiles with type errors
-    "baseUrl": "./typings"
+    "baseUrl": "./typings",
+    "skipLibCheck": true // TODO: remove once https://github.com/DefinitelyTyped/DefinitelyTyped/issues/14324 resolved
   }
 }


### PR DESCRIPTION
This PR sets a server-side cookie, i.e. httpOnly, in order to authenticate access to raw deployments and realtime events. The cookie is set  when calling the `team` endpoint . The cookie is only set if both of these conditions are met:

1. The user was authenticated with an access_token passed in the Authorization header
2. The request didn't already contain an identical cookie

Properties of the cookie (see https://hapijs.com/api#serverstatename-options):

```
 ttl: a year from now
 isSecure: true if externalBaseUrl is https
 domain: parsed from externalBaseUrl
 path = '/'
 isHttpOnly: true
 isSameSite: false
 encoding: 'none'
 strictHeader: true
```

NOTE: in staging and production charles is under the same domain as the UI, so the cookies are sent with fetch credentials options `same-site` and `include`. In development the domain is different and only `include` works. EventSource sends cookies at least to the same domain, but I fear not to other ones, which presents challenges in development.

This PR also presents a solution to the problem of letting screenshotter access raw deployments without authentication. We now let Hapi create two connections, one in the specified port and another one incremented by one. The latter is not intended to be publicly accessible and serves raw deployments without authentication.  

TODO in a future PR:

- possibly set the cookie in other endpoints as well
- set the cookie path based on externalBaseUrl
- figure out the best way to differentiate between staging and production (maybe just have different paths)
- implement logout somehow
- implement CSRF protection
- read and understand this carefully: http://cryto.net/~joepie91/blog/2016/06/13/stop-using-jwt-for-sessions/ and make changes accordingly
- add more endpoints under the "intranet" connection: at least `status`.



