### PR TITLE
Open preview and comment endpoints for unauthenticated access

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,21 +3,8 @@
   "configurations": [
     {
       "type": "node",
-      "request": "launch",
-      "name": "Test",
-      "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
-      "args": [
-        "--compilers",
-        "ts:ts-node/register,tsx:ts-node/register",
-        "-t",
-        "1000000000",
-        "src/**/*-spec.ts"
-      ],
-      "env": {
-        "NODE_ENV": "test",
-        "TS_NODE_FAST": "true"
-      },
-      "cwd": "${workspaceRoot}",
+      "request": "attach",
+      "name": "Attach (Inspector Protocol)",
       "port": 9229,
       "protocol": "inspector"
     },
@@ -30,6 +17,7 @@
       "args": [],
       "cwd": "${workspaceRoot}",
       "preLaunchTask": null,
+      "runtimeExecutable": null,
       "runtimeArgs": [
         "--nolazy"
       ],
@@ -39,6 +27,19 @@
       "externalConsole": false,
       "sourceMaps": true,
       "outDir": "${workspaceRoot}/dist"
+    },
+    {
+      "name": "Run mocha",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+      "stopOnEntry": false,
+      "args": ["-t", "100000000", "dist/*/*-spec.js"],
+      "cwd": "${workspaceRoot}",
+      "runtimeExecutable": null,
+      "env": { "NODE_ENV": "test", "TEST_USE_REDIS": "true", "TEST_ECS": "true"},
+      "sourceMaps": true,
+      "outFiles": ["${workspaceRoot}/dist/**/*.js"]
     },
     {
       "name": "Attach",
@@ -53,6 +54,15 @@
       ],
       "localRoot": "${workspaceRoot}/dist",
       "remoteRoot": "/code/dist"
+    },
+    {
+      "name": "Attach to Process",
+      "type": "node",
+      "request": "attach",
+      "processId": "${command.PickProcess}",
+      "port": 5858,
+      "sourceMaps": false,
+      "outDir": null
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,8 +3,21 @@
   "configurations": [
     {
       "type": "node",
-      "request": "attach",
-      "name": "Attach (Inspector Protocol)",
+      "request": "launch",
+      "name": "Test",
+      "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+      "args": [
+        "--compilers",
+        "ts:ts-node/register,tsx:ts-node/register",
+        "-t",
+        "1000000000",
+        "src/**/*-spec.ts"
+      ],
+      "env": {
+        "NODE_ENV": "test",
+        "TS_NODE_FAST": "true"
+      },
+      "cwd": "${workspaceRoot}",
       "port": 9229,
       "protocol": "inspector"
     },
@@ -17,7 +30,6 @@
       "args": [],
       "cwd": "${workspaceRoot}",
       "preLaunchTask": null,
-      "runtimeExecutable": null,
       "runtimeArgs": [
         "--nolazy"
       ],
@@ -27,19 +39,6 @@
       "externalConsole": false,
       "sourceMaps": true,
       "outDir": "${workspaceRoot}/dist"
-    },
-    {
-      "name": "Run mocha",
-      "type": "node",
-      "request": "launch",
-      "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
-      "stopOnEntry": false,
-      "args": ["-t", "100000000", "dist/*/*-spec.js"],
-      "cwd": "${workspaceRoot}",
-      "runtimeExecutable": null,
-      "env": { "NODE_ENV": "test", "TEST_USE_REDIS": "true", "TEST_ECS": "true"},
-      "sourceMaps": true,
-      "outFiles": ["${workspaceRoot}/dist/**/*.js"]
     },
     {
       "name": "Attach",
@@ -54,15 +53,6 @@
       ],
       "localRoot": "${workspaceRoot}/dist",
       "remoteRoot": "/code/dist"
-    },
-    {
-      "name": "Attach to Process",
-      "type": "node",
-      "request": "attach",
-      "processId": "${command.PickProcess}",
-      "port": 5858,
-      "sourceMaps": false,
-      "outDir": null
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,33 +2,6 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "type": "node",
-      "request": "attach",
-      "name": "Attach (Inspector Protocol)",
-      "port": 9229,
-      "protocol": "inspector"
-    },
-    {
-      "name": "Launch",
-      "type": "node",
-      "request": "launch",
-      "program": "${workspaceRoot}/dist/app.js",
-      "stopOnEntry": true,
-      "args": [],
-      "cwd": "${workspaceRoot}",
-      "preLaunchTask": null,
-      "runtimeExecutable": null,
-      "runtimeArgs": [
-        "--nolazy"
-      ],
-      "env": {
-        "NODE_ENV": "development"
-      },
-      "externalConsole": false,
-      "sourceMaps": true,
-      "outDir": "${workspaceRoot}/dist"
-    },
-    {
       "name": "Run mocha",
       "type": "node",
       "request": "launch",
@@ -45,8 +18,9 @@
       "name": "Attach",
       "type": "node",
       "request": "attach",
-      "port": 5858,
-      "address": "localhost",
+      "port": 9229,
+      "protocol": "inspector",
+      "address": "0.0.0.0",
       "restart": true,
       "sourceMaps": true,
       "outFiles": [
@@ -54,15 +28,6 @@
       ],
       "localRoot": "${workspaceRoot}/dist",
       "remoteRoot": "/code/dist"
-    },
-    {
-      "name": "Attach to Process",
-      "type": "node",
-      "request": "attach",
-      "processId": "${command.PickProcess}",
-      "port": 5858,
-      "sourceMaps": false,
-      "outDir": null
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "test": "TS_NODE_FAST=true NODE_ENV=test mocha --opts mocha.opts",
     "system-test": "TS_NODE_FAST=true NODE_ENV=development mocha --opts mocha-integration.opts",
     "dot-test": "mocha --opts mocha.opts --reporter dot",
-    "dev": "npm run transpile && node-dev --inspect=${DEBUG_PORT:-9229} --nolazy dist/app.js",
+    "dev": "npm run transpile && node-dev --inspect=0.0.0.0:${DEBUG_PORT:-9229} --nolazy dist/app.js",
     "start": "node dist/app.js",
     "transpile": "tsc",
     "watch": "tsc -w",

--- a/src/authentication/authentication-hapi-plugin-spec.ts
+++ b/src/authentication/authentication-hapi-plugin-spec.ts
@@ -8,7 +8,7 @@ import * as sinonChai from 'sinon-chai';
 use(sinonChai);
 
 import { bootstrap } from '../config';
-import { getSignedAccessToken, getAccessToken } from '../config/config-test';
+import { getAccessToken, getSignedAccessToken } from '../config/config-test';
 import { getTestServer } from '../server/hapi';
 import { makeRequestWithAuthentication, MethodStubber, stubber } from '../shared/test';
 import { adminTeamNameInjectSymbol, charlesKnexInjectSymbol, openTeamNameInjectSymbol } from '../shared/types';
@@ -19,7 +19,7 @@ import {
 } from './authentication-hapi-plugin';
 import { generateAndSaveTeamToken, generateTeamToken, teamTokenLength } from './team-token';
 import { initializeTeamTokenTable } from './team-token-spec';
-import { AuthorizationStatus, RequestCredentials } from "./types";
+import { AuthorizationStatus, RequestCredentials } from './types';
 
 const defaultTeamTokenString = generateTeamToken();
 expect(defaultTeamTokenString.length).to.equal(teamTokenLength);

--- a/src/authentication/authentication-hapi-plugin-spec.ts
+++ b/src/authentication/authentication-hapi-plugin-spec.ts
@@ -8,7 +8,7 @@ import * as sinonChai from 'sinon-chai';
 use(sinonChai);
 
 import { bootstrap } from '../config';
-import { getAccessToken } from '../config/config-test';
+import { getSignedAccessToken, getAccessToken } from '../config/config-test';
 import { getTestServer } from '../server/hapi';
 import { makeRequestWithAuthentication, MethodStubber, stubber } from '../shared/test';
 import { adminTeamNameInjectSymbol, charlesKnexInjectSymbol, openTeamNameInjectSymbol } from '../shared/types';
@@ -19,13 +19,14 @@ import {
 } from './authentication-hapi-plugin';
 import { generateAndSaveTeamToken, generateTeamToken, teamTokenLength } from './team-token';
 import { initializeTeamTokenTable } from './team-token-spec';
+import { AuthorizationStatus, RequestCredentials } from "./types";
 
 const defaultTeamTokenString = generateTeamToken();
 expect(defaultTeamTokenString.length).to.equal(teamTokenLength);
 const defaultEmail = 'foo@bar.com';
 const defaultSub = 'idp|12345678';
 
-const validAccessToken = getAccessToken(defaultSub, defaultTeamTokenString, defaultEmail);
+const validAccessToken = getSignedAccessToken(defaultSub, defaultTeamTokenString, defaultEmail);
 const invalidAccessToken = `${validAccessToken}a`;
 const makeRequest = makeRequestWithAuthentication(validAccessToken);
 
@@ -91,7 +92,7 @@ describe('authentication-hapi-plugin', () => {
         method: 'GET',
         url: 'http://foo.com/team',
         headers: {
-          'Authorization': `Bearer ${getAccessToken('abc')}`,
+          'Authorization': `Bearer ${getSignedAccessToken('abc')}`,
         },
       });
 
@@ -242,7 +243,6 @@ describe('authentication-hapi-plugin', () => {
     });
   });
   describe('team endpoint', () => {
-
     it('should be able to fetch caller\'s team', async () => {
       // Arrange
       const callerTeamId = 1;
@@ -280,7 +280,7 @@ describe('authentication-hapi-plugin', () => {
         ],
       );
       const teamToken = await generateAndSaveTeamToken(callerTeamId, db);
-      const accessToken = getAccessToken(defaultSub, teamToken.token, defaultEmail);
+      const accessToken = getSignedAccessToken(defaultSub, teamToken.token, defaultEmail);
 
       // Act
       const response = await makeRequestWithAuthentication(accessToken)(server, `/signup`);
@@ -318,7 +318,6 @@ describe('authentication-hapi-plugin', () => {
       expect((result.message as string).indexOf(defaultEmail)).to.not.eq(-1);
 
     });
-
   });
 
   describe('generatePassword', () => {
@@ -510,6 +509,113 @@ describe('authentication-hapi-plugin', () => {
       expect(result).to.be.true;
     });
   });
+  describe('userHasAccessToDeployment', () => {
+    it('returns true when the caller is already authorized', async () => {
+
+      // Arrange
+      const status = AuthorizationStatus.AUTHORIZED;
+      const { plugin } = await getPlugin();
+
+      // Act
+      const result = await plugin.userHasAccessToDeployment(1, 1, getRequestCredentials(status));
+
+      // Assert
+      expect(result).to.be.true;
+    });
+    it('returns true when the caller is not yet authorized but has access to project', async () => {
+
+      // Arrange
+      const status = AuthorizationStatus.NOT_CHECKED;
+      const { plugin } = await getPlugin(
+        (p: AuthenticationHapiPlugin) => [
+          sinon.stub(p, p._userHasAccessToProject.name)
+            .returns(Promise.resolve(true)),
+        ],
+      );
+
+      // Act
+      const result = await plugin.userHasAccessToDeployment(1, 1, getRequestCredentials(status));
+
+      // Assert
+      expect(result).to.be.true;
+      expect(plugin._userHasAccessToProject).to.have.been.calledOnce;
+    });
+
+    it('returns true when the caller is not authorized but the deployment is open', async () => {
+
+      // Arrange
+      const status = AuthorizationStatus.UNAUTHORIZED;
+      const { plugin } = await getPlugin(
+        (p: AuthenticationHapiPlugin) => [
+          sinon.stub(p, p.isOpenDeployment.name)
+            .returns(Promise.resolve(true)),
+        ],
+      );
+
+      // Act
+      const result = await plugin.userHasAccessToDeployment(1, 1, getRequestCredentials(status));
+
+      // Assert
+      expect(result).to.be.true;
+      expect(plugin.isOpenDeployment).to.have.been.calledOnce;
+    });
+
+    it('returns true when no credentials are provided but the deployment is open', async () => {
+
+      // Arrange
+      const { plugin } = await getPlugin(
+        (p: AuthenticationHapiPlugin) => [
+          sinon.stub(p, p.isOpenDeployment.name)
+            .returns(Promise.resolve(true)),
+        ],
+      );
+
+      // Act
+      const result = await plugin.userHasAccessToDeployment(1, 1);
+
+      // Assert
+      expect(result).to.be.true;
+      expect(plugin.isOpenDeployment).to.have.been.calledOnce;
+    });
+
+    it('returns false when the caller is not authorized and the deployment is not open', async () => {
+
+      // Arrange
+      const status = AuthorizationStatus.UNAUTHORIZED;
+      const { plugin } = await getPlugin(
+        (p: AuthenticationHapiPlugin) => [
+          sinon.stub(p, p.isOpenDeployment.name)
+            .returns(Promise.resolve(false)),
+        ],
+      );
+
+      // Act
+      const result = await plugin.userHasAccessToDeployment(1, 1, getRequestCredentials(status));
+
+      // Assert
+      expect(result).to.be.false;
+      expect(plugin.isOpenDeployment).to.have.been.calledOnce;
+    });
+
+    it('returns false when no credentials are provided and the deployment is not open', async () => {
+
+      // Arrange
+      const { plugin } = await getPlugin(
+        (p: AuthenticationHapiPlugin) => [
+          sinon.stub(p, p.isOpenDeployment.name)
+            .returns(Promise.resolve(false)),
+        ],
+      );
+
+      // Act
+      const result = await plugin.userHasAccessToDeployment(1, 1);
+
+      // Assert
+      expect(result).to.be.false;
+      expect(plugin.isOpenDeployment).to.have.been.calledOnce;
+    });
+
+  });
   describe('_isAdmin', () => {
     it('returns true if the user belongs to a team with the correct name', async () => {
 
@@ -618,3 +724,10 @@ describe('authentication-hapi-plugin', () => {
     });
   });
 });
+
+function getRequestCredentials(authorizationStatus: AuthorizationStatus): RequestCredentials {
+  return {
+    ...getAccessToken('foo|123123'),
+    authorizationStatus,
+  };
+}

--- a/src/authentication/authentication-hapi-plugin.ts
+++ b/src/authentication/authentication-hapi-plugin.ts
@@ -527,6 +527,7 @@ class AuthenticationHapiPlugin extends HapiPlugin {
     projectId: number,
     deploymentId: number,
     credentials?: RequestCredentials,
+    allowAnonymousAccessToOpenDeployments = true,
   ) {
     try {
     // If it's AUTHORIZED, it was checked on the top level
@@ -536,7 +537,7 @@ class AuthenticationHapiPlugin extends HapiPlugin {
         (credentials && credentials.authorizationStatus === AuthorizationStatus.AUTHORIZED) ||
         (credentials && credentials.authorizationStatus === AuthorizationStatus.NOT_CHECKED &&
           (await this.userHasAccessToProject(credentials.username!, projectId))) ||
-        (await this.isOpenDeployment(projectId, deploymentId))
+        (allowAnonymousAccessToOpenDeployments && await this.isOpenDeployment(projectId, deploymentId))
       ) {
         return true;
       }

--- a/src/authentication/authentication-hapi-plugin.ts
+++ b/src/authentication/authentication-hapi-plugin.ts
@@ -522,6 +522,7 @@ class AuthenticationHapiPlugin extends HapiPlugin {
     try {
       if (
         (typeof credentialsOrUsername === 'object' &&
+          credentialsOrUsername !== null &&
           credentialsOrUsername.authorizationStatus === AuthorizationStatus.AUTHORIZED) ||
         (typeof credentialsOrUsername === 'string' &&
           await this.userHasAccessToProject(credentialsOrUsername, projectId)) ||

--- a/src/authentication/authentication-hapi-plugin.ts
+++ b/src/authentication/authentication-hapi-plugin.ts
@@ -353,7 +353,7 @@ class AuthenticationHapiPlugin extends HapiPlugin {
       return callback(
         undefined,
         authorizationStatus === AuthorizationStatus.AUTHORIZED ||
-        authorizationStatus === AuthorizationStatus.NOT_CHECKED,
+          authorizationStatus === AuthorizationStatus.NOT_CHECKED,
         {
           ...payload,
           authorizationStatus,
@@ -529,9 +529,9 @@ class AuthenticationHapiPlugin extends HapiPlugin {
     credentials?: RequestCredentials,
   ) {
     try {
-      // If it's AUTHORIZED, it was checked on the top level
-      // If it's NOT_CHECKED, we need to chek here
-      // Otherwise only allow access to open deployments
+    // If it's AUTHORIZED, it was checked on the top level
+    // If it's NOT_CHECKED, we need to check here
+    // Otherwise only allow access to open deployments
     if (
         (credentials && credentials.authorizationStatus === AuthorizationStatus.AUTHORIZED) ||
         (credentials && credentials.authorizationStatus === AuthorizationStatus.NOT_CHECKED &&

--- a/src/authentication/json-api-authorization-spec.ts
+++ b/src/authentication/json-api-authorization-spec.ts
@@ -319,18 +319,19 @@ describe('authorization for api routes', () => {
         expect(api.deleteCommentHandler).to.not.have.been.called;
         expect(response.statusCode).to.eq(401);
       });
-      it('should allow deleting a comment for an open deployment without authentication', async () => {
+      it('should not allow deleting a comment for an open deployment without authentication', async () => {
         // Arrange
         const { server, authentication, api } = await arrangeCommentRemoval(true, true);
         // Act
-        await server.inject({
+        const response = await server.inject({
           method: 'DELETE',
           url: 'http://foo.com/comments/1',
         });
         // Assert
         expect(api.getComment).to.have.been.calledOnce;
-        expect(authentication.isOpenDeployment).to.have.been.calledOnce;
-        expect(api.deleteCommentHandler).to.have.been.calledOnce;
+        expect(authentication.isOpenDeployment).to.not.have.been.called;
+        expect(api.deleteCommentHandler).to.not.have.been.called;
+        expect(response.statusCode).to.eq(401);
       });
 
     });

--- a/src/authentication/json-api-authorization-spec.ts
+++ b/src/authentication/json-api-authorization-spec.ts
@@ -5,7 +5,7 @@ import * as sinonChai from 'sinon-chai';
 use(sinonChai);
 
 import { bootstrap } from '../config';
-import { getAccessToken } from '../config/config-test';
+import { getSignedAccessToken } from '../config/config-test';
 import { JsonApiHapiPlugin } from '../json-api';
 import { ProjectModule } from '../project';
 import { getTestServer } from '../server/hapi';
@@ -13,7 +13,7 @@ import { makeRequestWithAuthentication, MethodStubber, stubber } from '../shared
 import AuthenticationHapiPlugin from './authentication-hapi-plugin';
 import { generateTeamToken } from './team-token';
 
-const validAccessToken = getAccessToken('idp|12345678', generateTeamToken(), 'foo@bar.com');
+const validAccessToken = getSignedAccessToken('idp|12345678', generateTeamToken(), 'foo@bar.com');
 const makeRequest = makeRequestWithAuthentication(validAccessToken);
 
 async function getServer(

--- a/src/authentication/raw-deployment-authorization-spec.ts
+++ b/src/authentication/raw-deployment-authorization-spec.ts
@@ -6,14 +6,14 @@ import * as sinonChai from 'sinon-chai';
 use(sinonChai);
 
 import { bootstrap } from '../config';
-import { getAccessToken } from '../config/config-test';
+import { getSignedAccessToken } from '../config/config-test';
 import { DeploymentHapiPlugin } from '../deployment';
 import { getTestServer } from '../server/hapi';
 import { MethodStubber, stubber } from '../shared/test';
 import AuthenticationHapiPlugin from './authentication-hapi-plugin';
 import { generateTeamToken } from './team-token';
 
-const validAccessToken = getAccessToken('idp|12345678', generateTeamToken(), 'foo@bar.com');
+const validAccessToken = getSignedAccessToken('idp|12345678', generateTeamToken(), 'foo@bar.com');
 const deploymentDomain = 'deployment.foo.com';
 const validDeploymentUrl = `http://master-abcdef-1-1.${deploymentDomain}`;
 async function getServer(

--- a/src/authentication/raw-deployment-authorization-spec.ts
+++ b/src/authentication/raw-deployment-authorization-spec.ts
@@ -38,33 +38,22 @@ async function getServer(
   };
 }
 
-type AuthorizationMethod = 'userHasAccessToProject' | 'userHasAccessToTeam' | 'isOpenDeployment';
-
 function arrange(
-  authorizationMethod: AuthorizationMethod,
   hasAccess: boolean,
+  isOpenDeployment = false,
 ) {
   return getServer(
-    p => {
-      if (authorizationMethod === 'isOpenDeployment') {
+    (p: AuthenticationHapiPlugin) => {
         return [
-          sinon.stub(p, authorizationMethod)
-            .returns(Promise.resolve(hasAccess)),
-          sinon.stub(p, p.isAdmin.name)
-            .returns(Promise.resolve(false)),
-        ];
-      } else {
-        return [
-          sinon.stub(p, authorizationMethod)
+          sinon.stub(p, p.userHasAccessToDeployment.name)
             .returns(Promise.resolve(hasAccess)),
           sinon.stub(p, p.isAdmin.name)
             .returns(Promise.resolve(false)),
           sinon.stub(p, p.isOpenDeployment.name)
-            .returns(Promise.resolve(false)),
+            .returns(Promise.resolve(isOpenDeployment)),
         ];
-      }
     },
-    p => [
+    (p: DeploymentHapiPlugin) => [
       sinon.stub(p, p.checkDeploymentPre.name)
         .yields(200)
         .returns(Promise.resolve(true)),
@@ -84,30 +73,28 @@ function makeRequest(server: Server) {
 describe('authorization for raw deployments', () => {
   it('should allow accessing authorized deployments', async () => {
     // Arrange
-    const { server, authentication, handlerStub } = await arrange('userHasAccessToProject', true);
+    const { server, authentication, handlerStub } = await arrange(true);
     // Act
     const response = await makeRequest(server);
     // Assert
     expect(response.statusCode).to.exist;
-    expect(authentication.isOpenDeployment).to.have.been.calledOnce;
-    expect(authentication.userHasAccessToProject).to.have.been.calledOnce;
+    expect(authentication.userHasAccessToDeployment).to.have.been.calledOnce;
     expect(handlerStub).to.have.been.calledOnce;
   });
   it('should not allow accessing unauthorized deployments', async () => {
     // Arrange
-    const { server, authentication, handlerStub } = await arrange('userHasAccessToProject', false);
+    const { server, authentication, handlerStub } = await arrange(false);
     // Act
     const response = await makeRequest(server);
     // Assert
     expect(response.statusCode).to.eq(401);
-    expect(authentication.isOpenDeployment).to.have.been.calledOnce;
-    expect(authentication.userHasAccessToProject).to.have.been.calledOnce;
+    expect(authentication.userHasAccessToDeployment).to.have.been.calledOnce;
     expect(handlerStub).to.not.have.been.called;
 
   });
   it('should redirect to login screen for unauthenticated deployment requests', async () => {
     // Arrange
-    const { server, authentication, handlerStub } = await arrange('userHasAccessToProject', true);
+    const { server, authentication, handlerStub } = await arrange(false);
     // Act
     const response = await server.inject({
       method: 'GET',
@@ -115,13 +102,23 @@ describe('authorization for raw deployments', () => {
     });
     // Assert
     expect(response.statusCode).to.eq(302);
-    expect(authentication.isOpenDeployment).to.have.been.calledOnce;
-    expect(authentication.userHasAccessToProject).to.not.have.been.called;
+    expect(authentication.userHasAccessToDeployment).to.have.been.calledOnce;
     expect(handlerStub).to.not.have.been.called;
+  });
+  it('should allow authorized access to open deployments', async () => {
+    // Arrange
+    const { server, authentication, handlerStub } = await arrange(true, true);
+    // Act
+    const response = await makeRequest(server);
+
+    // Assert
+    expect(response.statusCode).to.exist;
+    expect(authentication.userHasAccessToDeployment).to.have.been.calledOnce;
+    expect(handlerStub).to.have.been.calledOnce;
   });
   it('should allow open access to open deployments', async () => {
     // Arrange
-    const { server, authentication, handlerStub } = await arrange('isOpenDeployment', true);
+    const { server, authentication, handlerStub } = await arrange(true, true);
     // Act
     const response = await server.inject({
       method: 'GET',
@@ -129,7 +126,7 @@ describe('authorization for raw deployments', () => {
     });
     // Assert
     expect(response.statusCode).to.exist;
-    expect(authentication.isOpenDeployment).to.have.been.calledOnce;
+    expect(authentication.userHasAccessToDeployment).to.have.been.calledOnce;
     expect(handlerStub).to.have.been.calledOnce;
   });
 });

--- a/src/authentication/types.ts
+++ b/src/authentication/types.ts
@@ -30,3 +30,9 @@ export const enum AuthorizationStatus {
 export type Authorizer = (userName: string, request: Request) => Promise<AuthorizationStatus>;
 
 export type RequestCredentials = undefined | (AccessToken & { authorizationStatus: AuthorizationStatus });
+
+export const STRATEGY_TOPLEVEL_USER_HEADER = 'jwt-user-header';
+export const STRATEGY_TOPLEVEL_USER_URL = 'jwt-user-url';
+export const STRATEGY_ROUTELEVEL_ADMIN_HEADER = 'jwt-admin-header';
+export const STRATEGY_ROUTELEVEL_USER_HEADER = 'jwt-route-user-header';
+export const STRATEGY_ROUTELEVEL_USER_COOKIE = 'jwt-route-user-cookie';

--- a/src/config/config-test.ts
+++ b/src/config/config-test.ts
@@ -9,6 +9,7 @@ import {
   jwtOptionsInjectSymbol,
   teamTokenClaimKey,
 } from '../authentication';
+import { sanitizeUsername } from '../authentication/authentication-hapi-plugin';
 import AuthenticationModule from '../authentication/authentication-module';
 import { eventStoreConfigInjectSymbol } from '../event-bus';
 import { JsonApiHapiPlugin } from '../json-api';
@@ -19,7 +20,6 @@ import { GitlabClient } from '../shared/gitlab-client';
 import Logger, { loggerInjectSymbol } from '../shared/logger';
 import { charlesKnexInjectSymbol, fetchInjectSymbol } from '../shared/types';
 import developmentConfig from './config-development';
-import { sanitizeUsername } from "../authentication/authentication-hapi-plugin";
 
 const logger = Logger(undefined, true);
 

--- a/src/deployment/deployment-hapi-plugin.ts
+++ b/src/deployment/deployment-hapi-plugin.ts
@@ -5,6 +5,7 @@ import * as Joi from 'joi';
 import * as memoizee from 'memoizee';
 import * as path from 'path';
 
+import { STRATEGY_ROUTELEVEL_USER_COOKIE } from '../authentication';
 import * as Hapi from '../server/hapi';
 import { HapiPlugin } from '../server/hapi-register';
 import { minardUiBaseUrlInjectSymbol } from '../server/types';
@@ -98,7 +99,7 @@ class DeploymentHapiPlugin extends HapiPlugin {
   protected rawDeploymentRoutes(requiresAuthorization = true): Hapi.IRouteConfiguration[] {
     const auth = {
       mode: 'try',
-      strategies: ['customAuthorize-cookie'],
+      strategies: [STRATEGY_ROUTELEVEL_USER_COOKIE],
     };
     return [{
       method: 'GET',
@@ -145,10 +146,7 @@ class DeploymentHapiPlugin extends HapiPlugin {
     try {
       const projectId: number = request.pre[PREKEY].projectId;
       const deploymentId: number = request.pre[PREKEY].deploymentId;
-      if (
-        await request.isOpenDeployment(projectId, deploymentId) ||
-        (request.auth.isAuthenticated && await request.userHasAccessToProject(projectId))
-      ) {
+      if (await request.userHasAccessToDeployment(projectId, deploymentId, request.auth.credentials)) {
         return reply('ok');
       }
     } catch (exception) {

--- a/src/integration-test/system-integration-tests.ts
+++ b/src/integration-test/system-integration-tests.ts
@@ -13,7 +13,7 @@ import 'reflect-metadata';
 
 import { generateAndSaveTeamToken, TeamToken } from '../authentication/team-token';
 import { bootstrap } from '../config';
-import { getAccessToken } from '../config/config-test';
+import { getSignedAccessToken } from '../config/config-test';
 import { JsonApiEntity, JsonApiResponse } from '../json-api';
 import { fetch as originalFetch } from '../shared/fetch';
 import { Group, User } from '../shared/gitlab';
@@ -166,7 +166,7 @@ describe('system-integration', () => {
       this.timeout(1000 * 30);
       logTitle(`Creating an admin user to the admin team ${adminTeam.name}`);
       const adminTeamToken = await generateAndSaveTeamToken(adminTeam.id, charlesDb);
-      adminAccessToken = getAccessToken(
+      adminAccessToken = getSignedAccessToken(
         `integration|1${randomComponent}`,
         adminTeamToken.token,
         `admin${randomComponent}@integration.com`,
@@ -184,7 +184,7 @@ describe('system-integration', () => {
       logTitle(`Signing up a user to team ${userTeam.name}`);
       const userTeamToken = await (await adminFetch(`${charles}/team-token/${userTeam.id}`, { method: 'POST' }))
         .tryJson<TeamToken>();
-      userAccessToken = getAccessToken(
+      userAccessToken = getSignedAccessToken(
         `integration|2${randomComponent}`,
         userTeamToken.token,
         `user${randomComponent}@integration.com`,
@@ -199,7 +199,7 @@ describe('system-integration', () => {
       logTitle(`Signing up a user to team ${openTeam.name}`);
       const openTeamToken = await (await adminFetch(`${charles}/team-token/${openTeam.id}`, { method: 'POST' }))
         .tryJson<TeamToken>();
-      openAccessToken = getAccessToken(
+      openAccessToken = getSignedAccessToken(
         `integration|3${randomComponent}`,
         openTeamToken.token,
         `openUser${randomComponent}@integration.com`,

--- a/src/json-api/json-api-hapi-plugin.ts
+++ b/src/json-api/json-api-hapi-plugin.ts
@@ -762,7 +762,8 @@ export class JsonApiHapiPlugin {
       if (!parsed) {
         return reply(Boom.badRequest('Invalid deployment id'));
       }
-      if (await request.userHasAccessToDeployment(parsed.projectId, parsed.deploymentId, request.auth.credentials)) {
+      const { projectId, deploymentId } = parsed;
+      if (await request.userHasAccessToDeployment(projectId, deploymentId, request.auth.credentials, false)) {
         return reply(commentId);
       }
     } catch (exception) {

--- a/src/json-api/json-api-hapi-plugin.ts
+++ b/src/json-api/json-api-hapi-plugin.ts
@@ -531,17 +531,17 @@ export class JsonApiHapiPlugin {
   }
 
   public async getProjectHandler(request: Hapi.Request, reply: Hapi.IReply) {
-    const projectId = (request.params as any).projectId;
+    const projectId = Number(request.params.projectId);
     return reply(this.getEntity('project', api => api.getProject(projectId)));
   }
 
   public async getProjectBranchesHandler(request: Hapi.Request, reply: Hapi.IReply) {
-    const projectId = (request.params as any).projectId;
+    const projectId = Number(request.params.projectId);
     return reply(this.getEntity('branch', api => api.getProjectBranches(projectId)));
   }
 
   public async getProjectsHandler(request: Hapi.Request, reply: Hapi.IReply) {
-    const teamId = (request.params as any).teamId;
+    const teamId = Number(request.params.teamId);
     return reply(this.getEntity('project', api => api.getProjects(teamId)));
   }
 
@@ -567,7 +567,7 @@ export class JsonApiHapiPlugin {
 
   public async patchProjectHandler(request: Hapi.Request, reply: Hapi.IReply) {
     const attributes = request.payload.data.attributes;
-    const projectId = (request.params as any).projectId;
+    const projectId = Number(request.params.projectId);
     if (!attributes.name && !attributes.description) {
       // Require that at least something is edited
       throw Boom.badRequest();
@@ -577,14 +577,14 @@ export class JsonApiHapiPlugin {
   }
 
   public async deleteProjectHandler(request: Hapi.Request, reply: Hapi.IReply) {
-    const projectId = (request.params as any).projectId;
+    const projectId = Number(request.params.projectId);
     await this.jsonApi.deleteProject(projectId);
     return reply({});
   }
 
   public async getDeploymentHandler(request: Hapi.Request, reply: Hapi.IReply) {
-    const projectId = Number((request.params as any).projectId);
-    const deploymentId = Number((request.params as any).deploymentId);
+    const projectId = Number(request.params.projectId);
+    const deploymentId = Number(request.params.deploymentId);
     return reply(this.getEntity('deployment', api => api.getDeployment(projectId, deploymentId)));
   }
 
@@ -605,7 +605,7 @@ export class JsonApiHapiPlugin {
   }
 
   public async getBranchHandler(request: Hapi.Request, reply: Hapi.IReply) {
-    const matches = parseApiBranchId((request.params as any).branchId);
+    const matches = parseApiBranchId(request.params.branchId);
     if (!matches) {
       throw Boom.badRequest('Invalid branch id');
     }
@@ -614,7 +614,7 @@ export class JsonApiHapiPlugin {
   }
 
   public async getBranchCommitsHandler(request: Hapi.Request, reply: Hapi.IReply) {
-    const matches = parseApiBranchId((request.params as any).branchId);
+    const matches = parseApiBranchId(request.params.branchId);
     if (!matches) {
       throw Boom.badRequest('Invalid branch id');
     }
@@ -628,8 +628,8 @@ export class JsonApiHapiPlugin {
   }
 
   public async getCommitHandler(request: Hapi.Request, reply: Hapi.IReply) {
-    const projectId = Number((request.params as any).projectId);
-    const hash = (request.params as any).hash as string;
+    const projectId = Number(request.params.projectId);
+    const hash = request.params.hash as string;
     return reply(this.getEntity('commit', api => api.getCommit(projectId, hash)));
   }
 
@@ -659,7 +659,7 @@ export class JsonApiHapiPlugin {
   }
 
   public async getProjectNotificationConfigurationsHandler(request: Hapi.Request, reply: Hapi.IReply) {
-    const projectId = (request.params as any).projectId;
+    const projectId = Number(request.params.projectId);
     return reply(this.getEntity('notification', api => api.getProjectNotificationConfigurations(projectId)));
   }
 
@@ -773,8 +773,7 @@ export class JsonApiHapiPlugin {
 
   public async postCommentHandler(request: Hapi.Request, reply: Hapi.IReply) {
     const { name, email, message } = request.payload.data.attributes;
-    const comment = await this.jsonApi.addComment(
-      request.pre.deploymentId, email, message, name || undefined);
+    const comment = await this.jsonApi.addComment(request.pre.deploymentId, email, message, name || undefined);
     return reply(this.serializeApiEntity('comment', comment))
       .created(`/api/comments/${comment.id}`);
   }

--- a/src/json-api/json-api-hapi-plugin.ts
+++ b/src/json-api/json-api-hapi-plugin.ts
@@ -4,7 +4,10 @@ import { inject, injectable } from 'inversify';
 import * as Joi from 'joi';
 import * as moment from 'moment';
 
-import { STRATEGY_ROUTELEVEL_USER_HEADER } from '../authentication/types';
+import {
+  STRATEGY_ROUTELEVEL_USER_HEADER,
+  STRATEGY_TOPLEVEL_USER_HEADER,
+} from '../authentication/types';
 import * as Hapi from '../server/hapi';
 import { HapiRegister } from '../server/hapi-register';
 import { externalBaseUrlInjectSymbol } from '../server/types';
@@ -104,7 +107,7 @@ export class JsonApiHapiPlugin {
 
     const openAuth = {
       mode: 'try',
-      strategies: [STRATEGY_ROUTELEVEL_USER_HEADER],
+      strategies: [STRATEGY_TOPLEVEL_USER_HEADER],
     };
 
     const deployment: Hapi.IRouteConfiguration[] = [{

--- a/src/operations/operations-hapi-plugin.ts
+++ b/src/operations/operations-hapi-plugin.ts
@@ -1,6 +1,7 @@
 
 import { inject, injectable } from 'inversify';
 
+import { STRATEGY_ROUTELEVEL_ADMIN_HEADER } from '../authentication';
 import * as Hapi from '../server/hapi';
 import { HapiRegister } from '../server/hapi-register';
 import OperationsModule from './operations-module';
@@ -23,7 +24,7 @@ export default class OperationsHapiPlugin {
 
   public register: HapiRegister = (server, _options, next) => {
     const config = {
-      auth: 'admin',
+      auth: STRATEGY_ROUTELEVEL_ADMIN_HEADER,
       bind: this,
     };
     server.route({

--- a/src/realtime/realtime-hapi-plugin.ts
+++ b/src/realtime/realtime-hapi-plugin.ts
@@ -71,9 +71,6 @@ export class RealtimeHapiPlugin extends HapiPlugin {
             projectId: Joi.number().required(),
             deploymentId: Joi.number().required(),
           },
-          query: {
-            sha: Joi.string(),
-          },
         },
       },
     }]);

--- a/src/realtime/realtime-hapi-plugin.ts
+++ b/src/realtime/realtime-hapi-plugin.ts
@@ -70,6 +70,9 @@ export class RealtimeHapiPlugin extends HapiPlugin {
             projectId: Joi.number().required(),
             deploymentId: Joi.number().required(),
           },
+          query: {
+            sha: Joi.string().required(),
+          },
         },
       },
     }]);

--- a/src/realtime/realtime-hapi-plugin.ts
+++ b/src/realtime/realtime-hapi-plugin.ts
@@ -72,7 +72,7 @@ export class RealtimeHapiPlugin extends HapiPlugin {
             deploymentId: Joi.number().required(),
           },
           query: {
-            sha: Joi.string().required(),
+            sha: Joi.string(),
           },
         },
       },

--- a/src/server/hapi.ts
+++ b/src/server/hapi.ts
@@ -24,7 +24,8 @@ declare module 'hapi' {
     userHasAccessToDeployment: (
       projectId: number,
       deploymentId: number,
-      credentialsOrUsername?: RequestCredentials | string,
+      credentials?: RequestCredentials,
+      allowAnonymousAccessToOpenDeployments?: boolean,
     ) => Promise<boolean>;
     isOpenDeployment: (projectId: number, deploymentId: number) => Promise<boolean>;
     getProjectTeam: (projectId: number) => Promise<{id: number, name: string}>;

--- a/src/server/hapi.ts
+++ b/src/server/hapi.ts
@@ -1,5 +1,6 @@
 export * from 'hapi';
 import { IReply, IRoute, IServerOptions, Request, Server } from 'hapi';
+import { RequestCredentials } from '../authentication';
 import { HapiRegister } from './hapi-register';
 
 interface PluginConfig {
@@ -20,6 +21,11 @@ declare module 'hapi' {
   interface RequestDecorators {
     userHasAccessToProject: (projectId: number) => Promise<boolean>;
     userHasAccessToTeam: (teamId: number) => Promise<boolean>;
+    userHasAccessToDeployment: (
+      projectId: number,
+      deploymentId: number,
+      credentialsOrUsername?: RequestCredentials | string,
+    ) => Promise<boolean>;
     isOpenDeployment: (projectId: number, deploymentId: number) => Promise<boolean>;
     getProjectTeam: (projectId: number) => Promise<{id: number, name: string}>;
   }

--- a/src/status/status-hapi-plugin.ts
+++ b/src/status/status-hapi-plugin.ts
@@ -4,6 +4,7 @@ import { HapiRegister } from '../server/hapi-register';
 
 import { inject, injectable } from 'inversify';
 
+import { STRATEGY_ROUTELEVEL_ADMIN_HEADER } from '../authentication';
 import * as logger from '../shared/logger';
 import { default as StatusModule, getEcsStatus } from './status-module';
 
@@ -48,7 +49,7 @@ class StatusHapiPlugin {
       },
       config: {
         bind: this,
-        auth: 'admin',
+        auth: STRATEGY_ROUTELEVEL_ADMIN_HEADER,
       },
     }, {
       method: 'GET',
@@ -68,7 +69,7 @@ class StatusHapiPlugin {
       },
       config: {
         bind: this,
-        auth: 'admin',
+        auth: STRATEGY_ROUTELEVEL_ADMIN_HEADER,
       },
     }].map((route: any) => {
       if (!auth) {


### PR DESCRIPTION
This PR adds unauthenticated access to the preview (GET) and comments (GET, POST, DELETE) of open deployments.

It also contains some refactoring to consolidate the deployment access checks into a request method `userHasAccessToDeployment`.