### PR TITLE
Enable CORS for deployment build trace endpoint

### DIFF
--- a/src/deployment/deployment-hapi-plugin.ts
+++ b/src/deployment/deployment-hapi-plugin.ts
@@ -83,6 +83,7 @@ class DeploymentHapiPlugin extends HapiPlugin {
         async: this.getTraceRequestHandler,
       },
       config: {
+        cors: true,
         bind: this,
         validate: {
           params: {


### PR DESCRIPTION
This is needed in order to fetch the build log from minard-ui.