### PR TITLE
Return team token from /team endpoint

### DIFF
--- a/src/authentication/authentication-hapi-plugin-spec.ts
+++ b/src/authentication/authentication-hapi-plugin-spec.ts
@@ -302,7 +302,7 @@ describe('authentication-hapi-plugin', () => {
       expect(response.statusCode).to.eq(200);
       expect(plugin._getUserGroups).to.have.been.calledOnce;
       const team = JSON.parse(response.payload);
-      expect(team['invitation-token']).to.eq(undefined);
+      expect(team['invitation-token']).to.be.undefined;
     });
   });
 

--- a/src/authentication/authentication-hapi-plugin-spec.ts
+++ b/src/authentication/authentication-hapi-plugin-spec.ts
@@ -284,6 +284,26 @@ describe('authentication-hapi-plugin', () => {
       const team = JSON.parse(response.payload);
       expect(team['invitation-token']).to.eq(teamTokenObject.token);
     });
+
+    it('should return undefined as the teamToken if one doesn\'t exist', async () => {
+      // Arrange
+      const callerTeamId = 1;
+      const { server, plugin } = await getServer(
+        (p: AuthenticationHapiPlugin) => [
+          sinon.stub(p, '_getUserGroups')
+            .returns(Promise.resolve([{ id: callerTeamId, name: 'foo' }])),
+        ],
+      );
+
+      // Act
+      const response = await makeRequest(server, `/team`);
+
+      // Assert
+      expect(response.statusCode).to.eq(200);
+      expect(plugin._getUserGroups).to.have.been.calledOnce;
+      const team = JSON.parse(response.payload);
+      expect(team['invitation-token']).to.eq(undefined);
+    });
   });
 
   describe('signup endpoint', () => {

--- a/src/authentication/authentication-hapi-plugin-spec.ts
+++ b/src/authentication/authentication-hapi-plugin-spec.ts
@@ -261,7 +261,28 @@ describe('authentication-hapi-plugin', () => {
       expect(plugin._getUserGroups).to.have.been.calledOnce;
       const team = JSON.parse(response.payload);
       expect(team.id).to.eq(callerTeamId);
+    });
 
+    it('should return the team\'s teamToken', async () => {
+      // Arrange
+      const callerTeamId = 1;
+      const { server, plugin, db } = await getServer(
+        (p: AuthenticationHapiPlugin) => [
+          sinon.stub(p, '_getUserGroups')
+            .returns(Promise.resolve([{ id: callerTeamId, name: 'foo' }])),
+        ],
+      );
+
+      const teamTokenObject = await generateAndSaveTeamToken(callerTeamId, db);
+
+      // Act
+      const response = await makeRequest(server, `/team`);
+
+      // Assert
+      expect(response.statusCode).to.eq(200);
+      expect(plugin._getUserGroups).to.have.been.calledOnce;
+      const team = JSON.parse(response.payload);
+      expect(team['invitation-token']).to.eq(teamTokenObject.token);
     });
   });
 

--- a/src/authentication/authentication-hapi-plugin.ts
+++ b/src/authentication/authentication-hapi-plugin.ts
@@ -206,9 +206,14 @@ class AuthenticationHapiPlugin extends HapiPlugin {
   public async getTeamHandler(request: Hapi.Request, reply: Hapi.IReply) {
     try {
       const credentials = request.auth.credentials as AccessToken;
-      const teams = await this._getUserGroups(sanitizeUsername(credentials.sub));
+      const username = sanitizeUsername(credentials.sub);
+      const teams = await this._getUserGroups(username);
+      const team = teams[0]; // NOTE: we only support a single team for now
       this.setAuthCookie(request, reply);
-      return reply(teams[0]); // NOTE: we only support a single team for now
+      const teamTokenResult = await teamTokenQuery(this.db, undefined, team.id);
+      const teamToken =
+        (teamTokenResult && teamTokenResult.length) ? teamTokenResult[0].token : undefined;
+      return reply({ ...team, 'invitation-token': teamToken });
     } catch (error) {
       this.logger.error(`Can't fetch user or team`, error);
       return reply(Boom.wrap(error, 404));

--- a/src/authentication/authentication-hapi-plugin.ts
+++ b/src/authentication/authentication-hapi-plugin.ts
@@ -210,7 +210,7 @@ class AuthenticationHapiPlugin extends HapiPlugin {
       const teams = await this._getUserGroups(username);
       const team = teams[0]; // NOTE: we only support a single team for now
       this.setAuthCookie(request, reply);
-      const teamTokenResult = await teamTokenQuery(this.db, undefined, team.id);
+      const teamTokenResult = await teamTokenQuery(this.db, { teamId: team.id });
       const teamToken =
         (teamTokenResult && teamTokenResult.length) ? teamTokenResult[0].token : undefined;
       return reply({ ...team, 'invitation-token': teamToken });
@@ -256,7 +256,7 @@ class AuthenticationHapiPlugin extends HapiPlugin {
       } else {
         return reply(Boom.create(401, `Insufficient privileges`));
       }
-      const teamToken = await teamTokenQuery(this.db, undefined, teamId);
+      const teamToken = await teamTokenQuery(this.db, { teamId });
       if (!teamToken || !teamToken.length) {
         throw new Error(`No token found for team ${teamId}`);
       }

--- a/src/authentication/team-token.ts
+++ b/src/authentication/team-token.ts
@@ -16,7 +16,8 @@ export interface TeamToken {
  * The results can be filtered by specifying a token,
  * a teamId or both.
  */
-export function teamTokenQuery(db: Knex, token?: string, teamId?: number) {
+export function teamTokenQuery(db: Knex, options: { token?: string, teamId?: number }) {
+  const { token, teamId } = options;
   const latestTokens = db('teamtoken')
     .select('teamId')
     .max('createdAt AS latestStamp')
@@ -50,7 +51,7 @@ export async function getTeamIdWithToken(token: string, db: Knex) {
   if (typeof token !== 'string') {
     throw new Error(`Token is not a string`);
   }
-  const teamTokens: TeamToken[] = await teamTokenQuery(db, token);
+  const teamTokens: TeamToken[] = await teamTokenQuery(db, { token });
   if (!teamTokens || teamTokens.length === 0) {
     throw new Error(`Unable to find teamId for the token ${token}`);
   }
@@ -77,7 +78,7 @@ export async function generateAndSaveTeamToken(teamId: number, db: Knex): Promis
       token: generateTeamToken(),
       createdAt: moment.utc().valueOf(),
     };
-    const existing = await teamTokenQuery(db, token.token);
+    const existing = await teamTokenQuery(db, { token: token.token });
     if (existing && existing.length > 0) {
       continue;
     }


### PR DESCRIPTION
We want to show the team's invitation URL in the UI, which means we need the currently active team token for all users. The `/team` endpoint seems like a natural place to add the token to. This PR adds the token to the `invitation-token` field.