### PR TITLE
Add Slack notifications

### DIFF
--- a/docs/api/api-notification.md
+++ b/docs/api/api-notification.md
@@ -11,12 +11,13 @@ Notification resources have the following attributes:
 
 Name|Type|Description
 ----|----|-----------
-`type`|"flowdock"&#124;"hipchat"|Type of activity
+`type`|"flowdock"&#124;"hipchat"&#124;"slack"|Type of activity
 `team-id`|string|Project id (only for team-scoped notifications)
 `project-id`|string|Project id (only for project-scoped notifications)
 `flow-token`|string|Flow token (only for `flowdock`)
 `hipchat-auth-token`|string|Hipchat authorization token (only for `hipchat`)
-`hipchat-room-id`|string|Hipchat room id(only for `hipchat`)
+`hipchat-room-id`|string|Hipchat room id (only for `hipchat`)
+`slack-webhook-url`|string|Slack webhook URL (only for `slack`)
 
 ## Add notification configuration
 
@@ -25,7 +26,7 @@ Name|Type|Description
 - Method: `POST`
 - URL: `/api/notifications`
 
-Payload for project-scoped Flowdock notification:
+Payload for project-scoped Flowdock notifications:
 ```json
 {
   "data": {
@@ -39,7 +40,7 @@ Payload for project-scoped Flowdock notification:
 }
 ```
 
-Payload for project-scoped HipChat notification
+Payload for project-scoped HipChat notifications:
 ```json
 {
   "data": {
@@ -54,7 +55,7 @@ Payload for project-scoped HipChat notification
 }
 ```
 
-Payload for team-scoped HipChat notification
+Payload for team-scoped HipChat notifications:
 ```json
 {
   "data": {
@@ -64,6 +65,20 @@ Payload for team-scoped HipChat notification
       "teamId": "[YOUR_TEAM_ID]",
       "hipchatAuthToken": "[YOUR_HIP_CHAT_AUTH_TOKEN]",
       "hipchatRoomId": "[YOUR_HIP_CHAT_ROOM_ID]"
+    }
+  }
+}
+```
+
+Payload for project-scoped Slack notifications:
+```json
+{
+  "data": {
+    "type": "notifications",
+    "attributes": {
+      "type": "slack",
+      "projectId": "[YOUR_PROJECT_ID]",
+      "slackWebhookUrl": "[YOUR_SLACK_WEBHOOK_URL]"
     }
   }
 }

--- a/migrations/notification/4-add-slack.js
+++ b/migrations/notification/4-add-slack.js
@@ -1,6 +1,6 @@
 exports.up = (knex) => Promise.all([
   knex.schema.table('notification_configuration', table => {
-    table.integer('slackWebhookUrl');
+    table.string('slackWebhookUrl');
   }),
 ]);
 

--- a/migrations/notification/4-add-slack.js
+++ b/migrations/notification/4-add-slack.js
@@ -1,0 +1,11 @@
+exports.up = (knex) => Promise.all([
+  knex.schema.table('notification_configuration', table => {
+    table.integer('slackWebhookUrl');
+  }),
+]);
+
+exports.down = (knex) => Promise.all([
+  knex.schema.table('notification_configuration', table => {
+    table.dropColumn('slackWebhookUrl');
+  }),
+]);

--- a/src/config/config-common.ts
+++ b/src/config/config-common.ts
@@ -89,6 +89,7 @@ import {
   FlowdockNotify,
   HipchatNotify,
   NotificationModule,
+  SlackNotify,
 } from '../notification';
 
 import { SystemHookModule } from '../system-hook';
@@ -130,6 +131,7 @@ export default new ContainerModule((bind, _unbind, _isBound, _rebind) => {
   bind(fetchInjectSymbol).toConstantValue(fetch);
   bind(FlowdockNotify.injectSymbol).to(FlowdockNotify);
   bind(HipchatNotify.injectSymbol).to(HipchatNotify);
+  bind(SlackNotify.injectSymbol).to(SlackNotify);
   bind(MinardServer.injectSymbol).to(MinardServer).inSingletonScope();
   bind(RemoteScreenshotter.injectSymbol).to(RemoteScreenshotter).inSingletonScope();
   bind(Migrations.injectSymbol).to(Migrations);

--- a/src/json-api/json-api-hapi-plugin.ts
+++ b/src/json-api/json-api-hapi-plugin.ts
@@ -1,4 +1,3 @@
-
 import * as Boom from 'boom';
 import { inject, injectable } from 'inversify';
 import * as Joi from 'joi';

--- a/src/json-api/json-api-hapi-plugin.ts
+++ b/src/json-api/json-api-hapi-plugin.ts
@@ -174,10 +174,12 @@ export class JsonApiHapiPlugin {
       config: {
         auth: STRATEGY_ROUTELEVEL_USER_HEADER,
         bind: this,
-        pre: [{
-          method: this.authorizeProjectCreation,
-          assign: 'teamId',
-        }],
+        pre: [
+          {
+            method: this.authorizeProjectCreation,
+            assign: 'teamId',
+          },
+        ],
         validate: {
           payload: {
             data: Joi.object({
@@ -329,13 +331,16 @@ export class JsonApiHapiPlugin {
       config: {
         bind: this,
         auth: STRATEGY_ROUTELEVEL_USER_HEADER,
-        pre: [{
-          method: this.parseActivityFilter,
-          assign: TEAM_OR_PROJECT_PRE_KEY,
-        }, {
-          method: this.authorizeTeamOrProjectAccess,
-          assign: 'filter',
-        }],
+        pre: [
+          {
+            method: this.parseActivityFilter,
+            assign: TEAM_OR_PROJECT_PRE_KEY,
+          },
+          {
+            method: this.authorizeTeamOrProjectAccess,
+            assign: 'filter',
+          },
+        ],
         validate: {
           query: {
             until: Joi.date(),
@@ -369,10 +374,12 @@ export class JsonApiHapiPlugin {
       config: {
         bind: this,
         auth: STRATEGY_ROUTELEVEL_USER_HEADER,
-        pre: [{
-          method: this.authorizeNotificationRemoval,
-          assign: 'notificationId',
-        }],
+        pre: [
+          {
+            method: this.authorizeNotificationRemoval,
+            assign: 'notificationId',
+          },
+        ],
         validate: {
           params: {
             id: Joi.number().required(),
@@ -388,13 +395,16 @@ export class JsonApiHapiPlugin {
       config: {
         bind: this,
         auth: STRATEGY_ROUTELEVEL_USER_HEADER,
-        pre: [{
-          method: this.tryGetNotificationConfiguration,
-          assign: TEAM_OR_PROJECT_PRE_KEY,
-        }, {
-          method: this.authorizeTeamOrProjectAccess,
-          assign: 'config',
-        }],
+        pre: [
+          {
+            method: this.tryGetNotificationConfiguration,
+            assign: TEAM_OR_PROJECT_PRE_KEY,
+          },
+          {
+            method: this.authorizeTeamOrProjectAccess,
+            assign: 'config',
+          },
+        ],
         validate: {
           payload: {
             data: Joi.object({
@@ -429,10 +439,12 @@ export class JsonApiHapiPlugin {
       config: {
         bind: this,
         auth: openAuth,
-        pre: [{
-          method: this.authorizeCommentRemoval,
-          assign: 'commentId',
-        }],
+        pre: [
+          {
+            method: this.authorizeCommentRemoval,
+            assign: 'commentId',
+          },
+        ],
         validate: {
           params: {
             id: Joi.number().required(),
@@ -448,10 +460,12 @@ export class JsonApiHapiPlugin {
       config: {
         bind: this,
         auth: openAuth,
-        pre: [{
-          method: this.authorizeCommentCreation,
-          assign: 'deploymentId',
-        }],
+        pre: [
+          {
+            method: this.authorizeCommentCreation,
+            assign: 'deploymentId',
+          },
+        ],
         validate: {
           payload: {
             data: Joi.object({

--- a/src/json-api/json-api-hapi-plugin.ts
+++ b/src/json-api/json-api-hapi-plugin.ts
@@ -423,6 +423,12 @@ export class JsonApiHapiPlugin {
                   hipchatRoomId: Joi.number().required(),
                   hipchatAuthToken: Joi.string().required(),
                 }),
+                Joi.object({
+                  type: Joi.string().equal('slack').required(),
+                  teamId: Joi.number(),
+                  projectId: Joi.number(),
+                  slackWebhookUrl: Joi.string().required(),
+                }),
               ),
             }).required(),
           },

--- a/src/json-api/serialization-spec.ts
+++ b/src/json-api/serialization-spec.ts
@@ -1,4 +1,3 @@
-
 import 'reflect-metadata';
 
 import { values } from 'lodash';

--- a/src/json-api/serialization-spec.ts
+++ b/src/json-api/serialization-spec.ts
@@ -17,6 +17,7 @@ import {
 import {
   FlowdockNotificationConfiguration,
   HipChatNotificationConfiguration,
+  SlackNotificationConfiguration,
 } from '../notification';
 
 import { serializeApiEntity } from './serialization';
@@ -443,7 +444,7 @@ describe('json-api serialization', () => {
         type: 'flowdock',
       };
 
-      const converted = serializeApiEntity('notification', notification, apiBaseUrl) as JsonApiResponse;
+      const converted: JsonApiResponse = serializeApiEntity('notification', notification, apiBaseUrl);
       const data = converted.data as JsonApiEntity;
       expect(data).to.exist;
 
@@ -467,7 +468,7 @@ describe('json-api serialization', () => {
         type: 'hipchat',
       } as any;
 
-      const converted = serializeApiEntity('notification', notification, apiBaseUrl) as JsonApiResponse;
+      const converted: JsonApiResponse = serializeApiEntity('notification', notification, apiBaseUrl);
       const data = converted.data as JsonApiEntity;
       expect(data).to.exist;
 
@@ -478,6 +479,29 @@ describe('json-api serialization', () => {
       // attributes
       expect(data.attributes['hipchat-room-id']).to.equal(notification.hipchatRoomId);
       expect(data.attributes['hipchat-auth-token']).to.equal(notification.hipchatAuthToken);
+      expect(data.attributes['team-id']).to.equal(notification.teamId);
+      expect(data.attributes.type).to.equal(notification.type);
+    });
+
+    it('should work with a Slack notification', () => {
+      const notification: SlackNotificationConfiguration = {
+        id: 5,
+        projectId: null,
+        teamId: 7,
+        slackWebhookUrl: 'http://fake.slack.url/for/notifications',
+        type: 'slack',
+      };
+
+      const converted: JsonApiResponse = serializeApiEntity('notification', notification, apiBaseUrl);
+      const data = converted.data as JsonApiEntity;
+      expect(data).to.exist;
+
+      // id and type
+      expect(data.id).to.equal(String(notification.id));
+      expect(data.type).to.equal('notifications');
+
+      // attributes
+      expect(data.attributes['slack-webhook-url']).to.equal(notification.slackWebhookUrl);
       expect(data.attributes['team-id']).to.equal(notification.teamId);
       expect(data.attributes.type).to.equal(notification.type);
     });

--- a/src/json-api/serialization.ts
+++ b/src/json-api/serialization.ts
@@ -44,7 +44,7 @@ export const commitSerialization = {
 };
 
 export const notificationSerialization = {
-  attributes: ['type', 'flowToken', 'projectId', 'teamId', 'hipchatRoomId', 'hipchatAuthToken'],
+  attributes: ['type', 'flowToken', 'projectId', 'teamId', 'hipchatRoomId', 'hipchatAuthToken', 'slackWebhookUrl'],
   ref: standardIdRef,
   included: false,
 };

--- a/src/notification/flowdock-manual-test.ts
+++ b/src/notification/flowdock-manual-test.ts
@@ -1,4 +1,3 @@
-
 // Script for manually testing flowdock notifications
 // during development
 

--- a/src/notification/flowdock-notify-spec.ts
+++ b/src/notification/flowdock-notify-spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from 'chai';
 import * as moment from 'moment';
 import 'reflect-metadata';

--- a/src/notification/flowdock-notify.ts
+++ b/src/notification/flowdock-notify.ts
@@ -1,4 +1,3 @@
-
 import * as gravatar from 'gravatar';
 import { inject, injectable } from 'inversify';
 
@@ -41,7 +40,8 @@ export class FlowdockNotify {
     branchUrl: string,
     previewUrl: string,
     commentUrl: string | undefined,
-    comment: NotificationComment | undefined) {
+    comment: NotificationComment | undefined,
+  ) {
     const state = deployment.status;
     const body = {
       flow_token: flowToken,
@@ -64,8 +64,7 @@ export class FlowdockNotify {
     previewUrl: string,
     commentUrl: string | undefined,
     comment: NotificationComment | undefined,
-    ): Promise<void> {
-
+  ): Promise<void> {
     const body = this.getBody(deployment, flowToken, projectUrl, branchUrl, previewUrl, commentUrl, comment);
     const fields = body.thread.fields;
 
@@ -184,7 +183,8 @@ export class FlowdockNotify {
     projectUrl: string,
     branchUrl: string,
     previewUrl: string,
-    _comment?: NotificationComment) {
+    _comment?: NotificationComment,
+  ) {
     const state = deployment.status;
     return {
       title: this.threadTitle(deployment),
@@ -207,7 +207,7 @@ export class FlowdockNotify {
     projectUrl: string,
     branchUrl: string,
     previewUrl: string,
-    ): ThreadField[] {
+  ): ThreadField[] {
     const fields: ThreadField[] = [];
 
     fields.push({

--- a/src/notification/hipchat-manual-test.ts
+++ b/src/notification/hipchat-manual-test.ts
@@ -1,4 +1,4 @@
-// Script for manually testing flowdock notifications
+// Script for manually testing HipChat notifications
 // during development
 
 import 'reflect-metadata';

--- a/src/notification/hipchat-manual-test.ts
+++ b/src/notification/hipchat-manual-test.ts
@@ -1,4 +1,3 @@
-
 // Script for manually testing flowdock notifications
 // during development
 

--- a/src/notification/hipchat-notify-spec.ts
+++ b/src/notification/hipchat-notify-spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from 'chai';
 import 'reflect-metadata';
 

--- a/src/notification/hipchat-notify.ts
+++ b/src/notification/hipchat-notify.ts
@@ -1,6 +1,4 @@
-
 import { inject, injectable } from 'inversify';
-
 import { truncate } from 'lodash';
 
 import {

--- a/src/notification/index.ts
+++ b/src/notification/index.ts
@@ -1,4 +1,3 @@
-
 export { NotificationModule } from './notification-module';
 export { FlowdockNotify } from './flowdock-notify';
 export { HipchatNotify } from './hipchat-notify';

--- a/src/notification/index.ts
+++ b/src/notification/index.ts
@@ -2,5 +2,6 @@
 export { NotificationModule } from './notification-module';
 export { FlowdockNotify } from './flowdock-notify';
 export { HipchatNotify } from './hipchat-notify';
+export { SlackNotify } from './slack-notify';
 
 export * from './types';

--- a/src/notification/notification-module-spec.ts
+++ b/src/notification/notification-module-spec.ts
@@ -1,4 +1,3 @@
-
 import { expect } from 'chai';
 import * as Knex from 'knex';
 import 'reflect-metadata';

--- a/src/notification/notification-module-spec.ts
+++ b/src/notification/notification-module-spec.ts
@@ -2,41 +2,16 @@ import { expect } from 'chai';
 import * as Knex from 'knex';
 import 'reflect-metadata';
 
-import {
-  createDeploymentEvent,
-  MinardDeployment,
-} from '../deployment';
-
-import {
-  LocalEventBus,
-} from '../event-bus';
-
+import { createDeploymentEvent, MinardDeployment } from '../deployment';
+import { LocalEventBus } from '../event-bus';
+import { getUiBranchUrl, getUiProjectUrl } from '../project';
+import { ScreenshotModule } from '../screenshot';
 import Logger from '../shared/logger';
-
-import {
-  HipchatNotify,
-} from './hipchat-notify';
-
-import {
-  FlowdockNotify,
-} from './flowdock-notify';
-
-import {
-  SlackNotify,
-} from './slack-notify';
-
-import {
-  getUiBranchUrl,
-  getUiProjectUrl,
-} from '../project';
-
-import {
-  ScreenshotModule,
-} from '../screenshot';
-
 import { sleep } from '../shared/sleep';
-
+import { FlowdockNotify } from './flowdock-notify';
+import { HipchatNotify } from './hipchat-notify';
 import { NotificationModule } from './notification-module';
+import { SlackNotify } from './slack-notify';
 
 const basicLogger = Logger(undefined, false);
 

--- a/src/notification/notification-module-spec.ts
+++ b/src/notification/notification-module-spec.ts
@@ -40,7 +40,7 @@ import { NotificationModule } from './notification-module';
 
 const basicLogger = Logger(undefined, false);
 
-describe.only('notification-module', () => {
+describe('notification-module', () => {
 
   async function setupKnex() {
     const knex = Knex({

--- a/src/notification/notification-module-spec.ts
+++ b/src/notification/notification-module-spec.ts
@@ -22,6 +22,10 @@ import {
 } from './flowdock-notify';
 
 import {
+  SlackNotify,
+} from './slack-notify';
+
+import {
   getUiBranchUrl,
   getUiProjectUrl,
 } from '../project';
@@ -36,7 +40,7 @@ import { NotificationModule } from './notification-module';
 
 const basicLogger = Logger(undefined, false);
 
-describe('notification-module', () => {
+describe.only('notification-module', () => {
 
   async function setupKnex() {
     const knex = Knex({
@@ -57,7 +61,12 @@ describe('notification-module', () => {
   const deploymentId = 77;
   const screenshotData = 'iVBORw0KGgoAAAANSUhEUgAA';
 
-  async function arrange(flowdockNotify: FlowdockNotify, bus: LocalEventBus, hipchatNotify: HipchatNotify) {
+  async function arrange(
+    flowdockNotify: FlowdockNotify,
+    bus: LocalEventBus,
+    hipchatNotify: HipchatNotify,
+    slackNotify: SlackNotify,
+  ) {
     const knex = await setupKnex();
 
     const screenshotModule = {} as ScreenshotModule;
@@ -66,7 +75,15 @@ describe('notification-module', () => {
     };
 
     const notificationModule = new NotificationModule(
-      bus, basicLogger, knex, uiBaseUrl, flowdockNotify, screenshotModule, hipchatNotify);
+      bus,
+      basicLogger,
+      knex,
+      uiBaseUrl,
+      flowdockNotify,
+      screenshotModule,
+      hipchatNotify,
+      slackNotify,
+    );
     await notificationModule.addConfiguration({
       type: 'flowdock',
       projectId,
@@ -97,7 +114,7 @@ describe('notification-module', () => {
         });
       };
     });
-    await arrange(flowdockNotify, bus, {} as any);
+    await arrange(flowdockNotify, bus, {} as any, {} as any);
 
     // Act
     const deployment = { projectId: _projectId, ref: 'foo', id: deploymentId, screenshot: 'foo', teamId: _teamId };
@@ -129,14 +146,19 @@ describe('notification-module', () => {
     expect(args._branchUrl).to.equal(getUiBranchUrl(projectId + 1, 'foo', uiBaseUrl));
   });
 
-  it('should trigger hipchat notification for DeploymentEvents', async () => {
+  it('should trigger HipChat notifications for DeploymentEvents', async () => {
     // Arrange
     const hipchatProjectId = 77;
     const bus = new LocalEventBus();
     const hipchatNotify = {} as HipchatNotify;
     const promise = new Promise<any>((resolve: any, _reject: any) => {
       hipchatNotify.notify = async (
-        deployment: MinardDeployment, roomId: number, authToken: string, _projectUrl: string, _branchUrl: string) => {
+        deployment: MinardDeployment,
+        roomId: number,
+        authToken: string,
+        _projectUrl: string,
+        _branchUrl: string,
+      ) => {
         resolve({
           deployment,
           roomId,
@@ -155,7 +177,7 @@ describe('notification-module', () => {
       hipchatAuthToken: 'foo-auth-token',
     };
 
-    const notificationModule = await arrange({} as any, bus, hipchatNotify);
+    const notificationModule = await arrange({} as any, bus, hipchatNotify, {} as any);
     await notificationModule.addConfiguration(config);
 
     // Act
@@ -178,6 +200,57 @@ describe('notification-module', () => {
     expect(args._branchUrl).to.equal(getUiBranchUrl(hipchatProjectId, deployment.ref, uiBaseUrl));
   });
 
+  it('should trigger Slack notifications for DeploymentEvents', async () => {
+    // Arrange
+    const mockUrl = 'http://fake.slack.webhook/url';
+    const slackProjectId = 12356732;
+    const bus = new LocalEventBus();
+    const slackNotify = {} as SlackNotify;
+    const promise = new Promise<any>((resolve: any, _reject: any) => {
+      slackNotify.notify = async (
+        deployment: MinardDeployment,
+        webhookUrl: string,
+        projectUrl: string,
+        branchUrl: string,
+      ) => {
+        resolve({
+          deployment,
+          webhookUrl,
+          projectUrl,
+          branchUrl,
+        });
+      };
+    });
+
+    const config = {
+      type: 'slack' as 'slack',
+      projectId: slackProjectId,
+      teamId: null,
+      slackWebhookUrl: mockUrl,
+    };
+
+    const notificationModule = await arrange({} as any, bus, {} as any, slackNotify);
+    const configurationResult = await notificationModule.addConfiguration(config);
+
+    // Act
+    const deployment = { projectId: slackProjectId, ref: 'foo', id: deploymentId, screenshot: 'foo', teamId: 7 };
+    bus.post(createDeploymentEvent({
+      teamId: 7,
+      deployment: deployment as any,
+      statusUpdate: { status: 'success' },
+    }));
+
+    // Assert
+    const result = await promise;
+    expect(configurationResult).to.be.a('number');
+    expect(result.deployment.projectId).to.equal(deployment.projectId);
+    expect(result.deployment.ref).to.equal(deployment.ref);
+    expect(result.deployment.id).to.equal(deploymentId);
+    expect(result.projectUrl).to.equal(getUiProjectUrl(slackProjectId, uiBaseUrl));
+    expect(result.branchUrl).to.equal(getUiBranchUrl(slackProjectId, deployment.ref, uiBaseUrl));
+    expect(result.webhookUrl).to.equal(mockUrl);
+  });
+
   async function shouldNotTriggerNotification(_projectId: number, statusUpdate: any) {
     // Arrange
     const bus = new LocalEventBus();
@@ -188,7 +261,7 @@ describe('notification-module', () => {
       console.log(`Error: Should not be called. Was called with projectId ${deployment.projectId}`);
       called = true;
     };
-    await arrange(flowdockNotify, bus, {} as any);
+    await arrange(flowdockNotify, bus, {} as any, {} as any);
 
     // Act
     const deployment = { projectId: _projectId, ref: 'foo', teamId: 9 };
@@ -212,13 +285,14 @@ describe('notification-module', () => {
   it('should be able to add, get and delete configurations', async () => {
     const _projectId = 9;
     // Arrange
-    const notificationModule = await arrange({} as any, new LocalEventBus(), {} as any);
+    const notificationModule = await arrange({} as any, new LocalEventBus(), {} as any, {} as any);
     const config = {
-      type: 'flowdock' as 'flowdock',
+      type: 'slack' as 'slack',
       projectId: _projectId,
-      flowToken: 'fake-flow-token',
+      flowToken: null,
       hipchatAuthToken: null,
       hipchatRoomId: null,
+      slackWebhookUrl: 'http://mock.slack.url/sdadsad',
       teamId: null,
     };
 
@@ -231,9 +305,11 @@ describe('notification-module', () => {
     const deletedForProject = await notificationModule.getProjectConfigurations(_projectId);
 
     // Assert
-    expect(existing).to.deep.equal(Object.assign(config, { id }));
+    expect(existing).to.deep.equal({ ...config, id });
+    expect(existing!.slackWebhookUrl).to.equal(config.slackWebhookUrl);
     expect(existingForProject).to.have.length(1);
-    expect(existingForProject[0]).to.deep.equal(Object.assign(config, { id}));
+    expect(existingForProject[0]).to.deep.equal({ ...config, id });
+    expect(existingForProject[0].slackWebhookUrl).to.equal(config.slackWebhookUrl);
     expect(deleted).to.equal(undefined);
     expect(deletedForProject).to.have.length(0);
   });

--- a/src/notification/notification-module.ts
+++ b/src/notification/notification-module.ts
@@ -256,7 +256,9 @@ export class NotificationModule {
       const { projectUrl, branchUrl, previewUrl, commentUrl, comment } = this.getBasicParams(event);
       const deployment: MinardDeployment = {
         ...event.payload.deployment,
-        screenshot: await this.getScreenshotData(event),
+        // TODO: Slack does not support sending image data in the payload.
+        // Figure out a way of getting a public URL for screenshots.
+        // screenshot: await this.getScreenshotData(event),
       };
       await this.slackNotify.notify(
         deployment,

--- a/src/notification/notification-module.ts
+++ b/src/notification/notification-module.ts
@@ -260,7 +260,7 @@ export class NotificationModule {
       };
       await this.slackNotify.notify(
         deployment,
-        config.flowToken,
+        config.slackWebhookUrl,
         projectUrl,
         branchUrl,
         previewUrl,

--- a/src/notification/notification-module.ts
+++ b/src/notification/notification-module.ts
@@ -152,7 +152,7 @@ export class NotificationModule {
         .from('notification_configuration')
         .where('teamId', teamId);
       const ret = await select;
-      return ret ? ret : [];
+      return ret || [];
     } catch (error) {
       this.logger.error('Failed to fetch notification configurations', error);
       throw Boom.badImplementation();
@@ -168,7 +168,7 @@ export class NotificationModule {
         .from('notification_configuration')
         .where('projectId', projectId);
       const ret = await select;
-      return ret ? ret : [];
+      return ret || [];
     } catch (error) {
       this.logger.error('Failed to fetch notification configurations', error);
       throw Boom.badImplementation();

--- a/src/notification/notification-module.ts
+++ b/src/notification/notification-module.ts
@@ -76,29 +76,15 @@ export class NotificationModule {
 
   public static injectSymbol = Symbol('notification-module');
 
-  private readonly eventBus: EventBus;
-  private readonly logger: Logger;
-  private readonly knex: Knex;
-  private readonly uiBaseUrl: string;
-  private readonly flowdockNotify: FlowdockNotify;
-  private readonly screenshotModule: ScreenshotModule;
-  private readonly hipchatNotify: HipchatNotify;
-
   constructor(
-    @inject(eventBusInjectSymbol) bus: EventBus,
-    @inject(loggerInjectSymbol) logger: Logger,
-    @inject(charlesKnexInjectSymbol) knex: Knex,
-    @inject(minardUiBaseUrlInjectSymbol) uiBaseUrl: string,
-    @inject(FlowdockNotify.injectSymbol) flowdockNotify: FlowdockNotify,
-    @inject(ScreenshotModule.injectSymbol) screenshotModule: ScreenshotModule,
-    @inject(HipchatNotify.injectSymbol) hipchatNotify: HipchatNotify) {
-    this.eventBus = bus;
-    this.logger = logger;
-    this.knex = knex;
-    this.uiBaseUrl = uiBaseUrl;
-    this.flowdockNotify = flowdockNotify;
-    this.hipchatNotify = hipchatNotify;
-    this.screenshotModule = screenshotModule;
+    @inject(eventBusInjectSymbol) private readonly eventBus: EventBus,
+    @inject(loggerInjectSymbol) private readonly logger: Logger,
+    @inject(charlesKnexInjectSymbol) private readonly knex: Knex,
+    @inject(minardUiBaseUrlInjectSymbol) private readonly uiBaseUrl: string,
+    @inject(FlowdockNotify.injectSymbol) private readonly flowdockNotify: FlowdockNotify,
+    @inject(ScreenshotModule.injectSymbol) private readonly screenshotModule: ScreenshotModule,
+    @inject(HipchatNotify.injectSymbol) private readonly hipchatNotify: HipchatNotify,
+  ) {
     this.subscribe();
   }
 
@@ -239,8 +225,10 @@ export class NotificationModule {
   public async notifyFlowdock(event: Event<NotificationEvent>, config: FlowdockNotificationConfiguration) {
     try {
       const { projectUrl, branchUrl, previewUrl, commentUrl, comment } = this.getBasicParams(event);
-      const deployment = Object.assign({}, event.payload.deployment,
-        { screenshot: await this.getScreenshotData(event) }) as MinardDeployment;
+      const deployment: MinardDeployment = {
+        ...event.payload.deployment,
+        screenshot: await this.getScreenshotData(event),
+      };
       await this.flowdockNotify.notify(
         deployment,
         config.flowToken,
@@ -248,7 +236,8 @@ export class NotificationModule {
         branchUrl,
         previewUrl,
         commentUrl,
-        comment);
+        comment,
+      );
     } catch (error) {
       this.logger.error(`Failed to send Flowdock notification`, error);
     }

--- a/src/notification/slack-manual-test.ts
+++ b/src/notification/slack-manual-test.ts
@@ -77,4 +77,3 @@ async function test() {
 }
 
 test().catch(err => console.log(err));
-

--- a/src/notification/slack-manual-test.ts
+++ b/src/notification/slack-manual-test.ts
@@ -1,0 +1,80 @@
+// Script for manually testing Slack notifications
+// during development
+
+import * as moment from 'moment';
+import 'reflect-metadata';
+
+import { MinardDeployment } from '../deployment';
+import { fetch, IFetch } from '../shared/fetch';
+import { SlackNotify } from './slack-notify';
+
+// const screenshot = fs.readFileSync('mini-camel.jpg') as Buffer;
+
+const slackNotify = new SlackNotify(fetch as IFetch);
+
+const slackWebhookUrl = process.env.SLACK_WEBHOOK_URL;
+
+const projectUrl = 'http://www.foo.com';
+const branchUrl = 'http://www.bar.com';
+const previewUrl = 'http://www.bar-ui.com/preview/5';
+const commentUrl = 'http://www.bar-ui.com/preview/5/comment/45';
+
+const deployment: MinardDeployment = {
+  id: 10,
+  teamId: 1,
+  projectId: Math.round(Math.random() * 10000),
+  status: 'success',
+  ref: 'foo-branch',
+  projectName: 'foo-project-name',
+  url: 'http://foo-deployment-url.com',
+  commitHash: 'abcdef12345',
+  buildStatus: 'success',
+  extractionStatus: 'success',
+  screenshotStatus: 'failed',
+  createdAt: moment(),
+  commit: {
+    id: 'foo-id',
+    shortId: 'foo-id',
+    message: 'foo',
+    committer: {
+      name: 'Ville Saarinen',
+      email: 'ville.saarinen@lucify.com',
+      timestamp: 'fake-timestamp',
+    },
+    author: {
+      name: 'Ville Saarinen',
+      email: 'ville.saarinen@lucify.com',
+      timestamp: 'fake-timestamp',
+    },
+  },
+};
+
+const comment = {
+  name: 'foo commenter',
+  email: 'foo@gjoo.com',
+  message: 'foo comment',
+};
+
+async function test() {
+ await slackNotify.notify(
+   deployment,
+   slackWebhookUrl,
+   projectUrl,
+   branchUrl,
+   previewUrl,
+   undefined,
+   undefined,
+ );
+ await slackNotify.notify(
+   deployment,
+   slackWebhookUrl,
+   projectUrl,
+   branchUrl,
+   previewUrl,
+   commentUrl,
+   comment,
+  );
+}
+
+test().catch(err => console.log(err));
+

--- a/src/notification/slack-notify-spec.ts
+++ b/src/notification/slack-notify-spec.ts
@@ -1,0 +1,117 @@
+import { expect } from 'chai';
+import * as moment from 'moment';
+import 'reflect-metadata';
+
+import { MinardDeployment } from '../deployment';
+import { fetchMock } from '../shared/fetch';
+import { SlackNotify } from './slack-notify';
+import { NotificationComment } from './types';
+
+describe('slack-notify', () => {
+  const baseDeployment: MinardDeployment = {
+    id: 10,
+    teamId: 1,
+    projectId: 3,
+    status: 'success',
+    ref: 'foo-branch',
+    projectName: 'foo-project-name',
+    url: 'http://foo-deployment-url.com',
+    commitHash: 'abcdef12345',
+    buildStatus: 'success',
+    extractionStatus: 'success',
+    screenshotStatus: 'failed',
+    screenshot: 'http://foo-deployentm.com/screenshot.jpg',
+    createdAt: moment(),
+    commit: {
+      id: 'foo-id',
+      shortId: 'foo-id',
+      message: 'foo',
+      committer: {
+        name: 'Ville Saarinen',
+        email: 'ville.saarinen@lucify.com',
+        timestamp: 'fake-timestamp',
+      },
+      author: {
+        name: 'Ville Saarinen',
+        email: 'ville.saarinen@lucify.com',
+        timestamp: 'fake-timestamp',
+      },
+    },
+  };
+
+  const deployment = baseDeployment;
+  const slackWebhookUrl = 'https://hooks.slack.com/services/FAKE/SLACK/WEBHOOKURL';
+  const projectUrl = 'http://foo-bar.com/projects/5';
+  const branchUrl = 'http://foo-bar.com/branches/1-5';
+  const previewUrl = 'http://foo-bar-ui.com/preview/1-5';
+
+  function arrange(): { notifier: SlackNotify, promise: Promise<any> } {
+    const notifier = new SlackNotify(fetchMock.fetchMock);
+    const promise = new Promise<any>((resolve, _reject) => {
+      const response = (_url: string, options: any) => {
+        resolve(options);
+        return {};
+      };
+      fetchMock.restore().mock(slackWebhookUrl, response, { method: 'POST' });
+    });
+    return { notifier, promise };
+  }
+
+  it('should send correct notification for deployment with screenshot', async () => {
+    // Arrange
+    const { notifier, promise } = arrange();
+
+    // Act
+    await notifier.notify(deployment, slackWebhookUrl, projectUrl, branchUrl, previewUrl, undefined, undefined);
+
+    // Assert
+    const options = await promise;
+    const body = JSON.parse(options.body);
+
+    expect(body.attachments).to.exist;
+
+    const attachment = body.attachments[0];
+
+    expect(attachment).to.exist;
+    expect(attachment.fallback).contains(previewUrl);
+    expect(attachment.fallback).contains('preview');
+    expect(attachment.color).equal('#40C1AC');
+    expect(attachment.author_name).equal(deployment.commit.committer.name);
+    expect(attachment.title).equal('New preview');
+    expect(attachment.title_link).equal(previewUrl);
+    expect(attachment.image_url).equal(deployment.screenshot);
+    expect(attachment.ts).equal(deployment.createdAt.unix());
+  });
+
+  it('should send correct notification for comment', async () => {
+    // Arrange
+    const { notifier, promise } = arrange();
+    const commentUrl = 'http://foo-bar-ui.com/preview/1-5/comment/6';
+    const comment: NotificationComment = {
+      email: 'foo@foomail.com',
+      name: 'foo woman',
+      message: 'foo msg',
+    };
+
+    // Act
+    await notifier.notify(deployment, slackWebhookUrl, projectUrl, branchUrl, previewUrl, commentUrl, comment);
+
+    // Assert
+    const options = await promise;
+    const body = JSON.parse(options.body);
+    expect(body.attachments).to.exist;
+
+    const attachment = body.attachments[0];
+
+    expect(attachment).to.exist;
+    expect(attachment.fallback).contains(commentUrl);
+    expect(attachment.fallback).contains('comment');
+    expect(attachment.color).equal('#40C1AC');
+    expect(attachment.author_name).equal(comment.name);
+    expect(attachment.title).equal('New comment');
+    expect(attachment.title_link).equal(commentUrl);
+    expect(attachment.image_url).equal(deployment.screenshot);
+    // TODO: check timestamp?
+  });
+
+});

--- a/src/notification/slack-notify.ts
+++ b/src/notification/slack-notify.ts
@@ -76,7 +76,7 @@ export class SlackNotify {
     previewUrl: string,
     commentUrl?: string,
     comment?: NotificationComment,
-  ): Promise<any> {
+  ): Promise<void> {
     // do not send notification for failed deployments
     if (deployment.status !== 'success') {
       return;

--- a/src/notification/slack-notify.ts
+++ b/src/notification/slack-notify.ts
@@ -14,11 +14,13 @@ export function getMessage(
   comment?: NotificationComment,
 ): SlackMessage {
   const author = comment || deployment.commit.author;
+  const fallback = `New ${comment ? 'comment' : 'preview'} in ` +
+    `${deployment.projectName}/${deployment.ref}: ${previewUrl}`;
 
   return {
     attachments: [
       {
-        fallback: `New preview in ${deployment.projectName}: ${previewUrl}`,
+        fallback,
         color: '#40C1AC',
         author_name: author.name,
         author_icon: gravatar.url(author.email),

--- a/src/notification/slack-notify.ts
+++ b/src/notification/slack-notify.ts
@@ -36,6 +36,7 @@ export function getMessage(
         short: true,
       },
     ],
+    // For some reason the footer icon doesn't work. It might require HTTP?
     footer_icon: 'https://minard.io/favicon-16x16.png',
     // TODO: Can a comment's timestamp be fetched from somewhere?
     ts: comment ? Date.now() / 1000 : deployment.createdAt.unix(),

--- a/src/notification/slack-notify.ts
+++ b/src/notification/slack-notify.ts
@@ -41,6 +41,7 @@ export function getMessage(
         ],
         image_url: deployment.screenshot,
         footer_icon: 'https://minard.io/favicon-16x16.png',
+        // TODO: Can a comment's timestamp be fetched from somewhere?
         ts: comment ? Date.now() / 1000 : deployment.createdAt.unix(),
       },
     ],

--- a/src/notification/slack-notify.ts
+++ b/src/notification/slack-notify.ts
@@ -1,0 +1,98 @@
+import * as gravatar from 'gravatar';
+import { inject, injectable } from 'inversify';
+
+import { MinardDeployment } from '../deployment';
+import { IFetch } from '../shared/fetch';
+import { fetchInjectSymbol } from '../shared/types';
+import { NotificationComment, SlackMessage } from './types';
+
+export function getMessage(
+  deployment: MinardDeployment,
+  previewUrl: string,
+  projectUrl: string,
+  branchUrl: string,
+  comment?: NotificationComment,
+): SlackMessage {
+  const author = comment || deployment.commit.author;
+
+  return {
+    attachments: [
+      {
+        fallback: `New preview in ${deployment.projectName}: ${previewUrl}`,
+        color: '#40C1AC',
+        author_name: author.name,
+        author_icon: gravatar.url(author.email),
+        title: comment ? 'New comment' : 'New preview',
+        title_link: previewUrl,
+        text: comment ? comment.message : deployment.commit.message,
+        fields: [
+          {
+            title: 'Project',
+            value: `<${projectUrl}|${deployment.projectName}>`,
+            short: true,
+          },
+          {
+            title: 'Branch',
+            value: `<${branchUrl}|${deployment.ref}>`,
+            short: true,
+          },
+        ],
+        image_url: deployment.screenshot,
+        footer_icon: 'https://minard.io/favicon-16x16.png',
+        ts: comment ? Date.now() / 1000 : deployment.createdAt.unix(),
+      },
+    ],
+  };
+}
+
+@injectable()
+export class SlackNotify {
+  public static injectSymbol = Symbol('slack-notify');
+  private fetch: IFetch;
+
+  public constructor(@inject(fetchInjectSymbol) fetch: IFetch) {
+    this.fetch = fetch;
+  }
+
+  public async notify(
+    deployment: MinardDeployment,
+    webhookUrl: string,
+    projectUrl: string,
+    branchUrl: string,
+    previewUrl: string,
+    commentUrl?: string,
+    comment?: NotificationComment,
+  ): Promise<any> {
+    // do not send notification for failed deployments
+    if (deployment.status !== 'success') {
+      return;
+    }
+
+    const fullPreviewUrl = commentUrl || previewUrl;
+    const body = getMessage(deployment, fullPreviewUrl, projectUrl, branchUrl, comment);
+
+    const options = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      json: true,
+      body: JSON.stringify(body),
+    };
+
+    const ret = await this.fetch(webhookUrl, options);
+    if (ret.status === 202 || ret.status === 200 || ret.status === 201 || ret.status === 204) {
+      return;
+    }
+
+    try {
+      const json = await ret.json();
+      throw Error(
+        `Unexpected status ${ret.status} when posting Slack notification. ` +
+        `Response was ${JSON.stringify(json, null, 2)}`,
+      );
+    } catch (error) {
+      throw Error(`Unexpected status ${ret.status} when posting Slack notification.`);
+    }
+  }
+}

--- a/src/notification/slack-notify.ts
+++ b/src/notification/slack-notify.ts
@@ -47,7 +47,7 @@ export function getMessage(
   }
 
   if (comment) {
-    message.fields.push({
+    message.fields.unshift({
       title: 'Commit',
       value: deployment.commit.message,
       short: false,

--- a/src/notification/slack-notify.ts
+++ b/src/notification/slack-notify.ts
@@ -20,7 +20,7 @@ export function getMessage(
     fallback,
     color: '#40C1AC',
     author_name: author.name,
-    author_icon: gravatar.url(author.email),
+    author_icon: gravatar.url(author.email, undefined, false),
     title: comment ? 'New comment' : 'New preview',
     title_link: previewUrl,
     text: comment ? comment.message : deployment.commit.message,

--- a/src/notification/types.ts
+++ b/src/notification/types.ts
@@ -1,5 +1,5 @@
 
-export type NotificationType = 'flowdock' | 'hipchat';
+export type NotificationType = 'flowdock' | 'hipchat' | 'slack';
 
 export interface HipChatNotificationConfiguration extends NotificationConfiguration {
   type: 'hipchat';
@@ -10,6 +10,11 @@ export interface HipChatNotificationConfiguration extends NotificationConfigurat
 export interface FlowdockNotificationConfiguration extends NotificationConfiguration {
   type: 'flowdock';
   flowToken: string;
+}
+
+export interface SlackNotificationConfiguration extends NotificationConfiguration {
+  type: 'slack';
+  slackWebhookUrl: string;
 }
 
 export interface NotificationConfiguration {
@@ -24,4 +29,30 @@ export interface NotificationComment {
   name?: string;
   email: string;
   message: string;
+}
+
+export interface SlackMessage {
+  attachments: SlackAttachment[];
+}
+
+export interface SlackAttachment {
+  fallback: string; // Required plain-text summary of the attachment
+  color?: string; // 'good', 'warning', 'danger', '#<hexcode>'
+  pretext?: string; // Optional text that appears above the attachment block
+  author_name?: string;
+  author_link?: string;
+  author_icon?: string;
+  title?: string;
+  title_link?: string;
+  text?: string; // "Optional text that appears within the attachment",
+  fields: { title: string; value: string; short?: boolean; }[];
+  // Large images will be resized to a maximum width of 400px or a maximum height of 500px,
+  // while still maintaining the original aspect ratio.
+  image_url?: string;
+  // Should be 75x75px. Must be less than 500kb.
+  thumb_url?: string;
+  footer?: string;
+  // Should be 16x16px
+  footer_icon?: string;
+  ts: number; // timestamp, integer, epoch time
 }

--- a/src/notification/types.ts
+++ b/src/notification/types.ts
@@ -1,4 +1,3 @@
-
 export type NotificationType = 'flowdock' | 'hipchat' | 'slack';
 
 export interface HipChatNotificationConfiguration extends NotificationConfiguration {

--- a/src/screenshot/screenshot-module.ts
+++ b/src/screenshot/screenshot-module.ts
@@ -59,7 +59,7 @@ export default class ScreenshotModule {
 
   public async getScreenshotData(projectId: number, deploymentId: number) {
     const path = this.getScreenshotPath(projectId, deploymentId);
-    return promisify(fs.readFile)(path);
+    return promisify<string>(fs.readFile)(path);
   }
 
   public getScreenshotPath(projectId: number, deploymentId: number) {


### PR DESCRIPTION
This PR adds support for Slack notifications. It works just like the Flowdock and HipChat notifications. Unfortunately, Slack doesn't support sending image data included in the message, which means that we'll get screenshots in Slack only once we can add support for public screenshots.

Setting up the notification is done with this type of payload to the notifications endpoint:

```json
{
  "data": {
    "type": "notifications",
    "attributes": {
      "type": "slack",
      "projectId": "[YOUR_PROJECT_ID]",
      "slackWebhookUrl": "[YOUR_SLACK_WEBHOOK_URL]"
    }
  }
}
```

The notifications currently look like this:

<img width="474" alt="screenshot 2017-05-04 15 54 54" src="https://cloud.githubusercontent.com/assets/888333/25704426/0abdfbcc-30e2-11e7-8f3b-5f92b3ee58a6.png">

<img width="464" alt="screenshot 2017-05-04 16 33 06" src="https://cloud.githubusercontent.com/assets/888333/25705848/679b48b8-30e7-11e7-8ce2-13cbc4bdb71b.png">


Still not completely happy with the contents of the messages—could definitely iterate on those. [Slack's documentation](https://api.slack.com/docs/message-attachments) is pretty good for that.