### PR TITLE
Support multiple open teams

### DIFF
--- a/src/authentication/authentication-hapi-plugin-spec.ts
+++ b/src/authentication/authentication-hapi-plugin-spec.ts
@@ -789,8 +789,9 @@ describe('authentication-hapi-plugin', () => {
 
       // Arrange
       const { plugin } = await getPlugin(
-        (p: AuthenticationHapiPlugin, k: Container) => {
-          const notOpenTeamName = k.get<string[]>(openTeamNamesInjectSymbol)[0] + 'foo';
+        (p: AuthenticationHapiPlugin, _k: Container) => {
+          const notOpenTeamName = 'notopenteamname';
+
           return [
             sinon.stub(p, p.getProjectTeam.name)
               .returns(Promise.resolve({ name: notOpenTeamName, id: 1 })),

--- a/src/authentication/authentication-hapi-plugin-spec.ts
+++ b/src/authentication/authentication-hapi-plugin-spec.ts
@@ -35,7 +35,7 @@ async function getPlugin(authenticationStubber?: MethodStubber<AuthenticationHap
   kernel.rebind(AuthenticationHapiPlugin.injectSymbol).to(AuthenticationHapiPlugin);
   const db = kernel.get<Knex>(charlesKnexInjectSymbol);
   kernel.rebind(charlesKnexInjectSymbol).toConstantValue(db);
-  kernel.rebind(openTeamNamesInjectSymbol).toConstantValue(['foo']);
+  kernel.rebind(openTeamNamesInjectSymbol).toConstantValue(['fooopenteam', 'baropenteam']);
   await initializeTeamTokenTable(db);
   if (authenticationStubber) {
     const { instance } = stubber(authenticationStubber, AuthenticationHapiPlugin.injectSymbol, kernel);
@@ -751,6 +751,26 @@ describe('authentication-hapi-plugin', () => {
       const { plugin } = await getPlugin(
         (p: AuthenticationHapiPlugin, k: Container) => {
           const openTeamName = k.get<string[]>(openTeamNamesInjectSymbol)[0];
+
+          return [
+            sinon.stub(p, p.getProjectTeam.name)
+              .returns(Promise.resolve({ name: openTeamName, id: 1 })),
+          ];
+        },
+      );
+
+      // Act
+      const result = await plugin.isOpenDeployment(1, 1);
+
+      // Assert
+      expect(result).to.be.true;
+    });
+    it('returns true if the project belongs to the second \'open\' team', async () => {
+
+      // Arrange
+      const { plugin } = await getPlugin(
+        (p: AuthenticationHapiPlugin, k: Container) => {
+          const openTeamName = k.get<string[]>(openTeamNamesInjectSymbol)[1];
 
           return [
             sinon.stub(p, p.getProjectTeam.name)

--- a/src/authentication/authentication-hapi-plugin.ts
+++ b/src/authentication/authentication-hapi-plugin.ts
@@ -14,7 +14,7 @@ import {
   adminTeamNameInjectSymbol,
   charlesKnexInjectSymbol,
   fetchInjectSymbol,
-  openTeamNameInjectSymbol,
+  openTeamNamesInjectSymbol,
 } from '../shared/types';
 import { generateAndSaveTeamToken, getTeamIdWithToken, teamTokenQuery } from './team-token';
 import {
@@ -49,7 +49,7 @@ class AuthenticationHapiPlugin extends HapiPlugin {
     @inject(charlesKnexInjectSymbol) private readonly db: Knex,
     @inject(loggerInjectSymbol) private readonly logger: Logger,
     @inject(adminTeamNameInjectSymbol) private readonly adminTeamName: string,
-    @inject(openTeamNameInjectSymbol) private readonly openTeamName: string,
+    @inject(openTeamNamesInjectSymbol) private readonly openTeamNames: string[],
     @inject(fetchInjectSymbol) private readonly fetch: IFetch,
     @inject(internalHostSuffixesInjectSymbol) private readonly internalHostSuffixes: string[],
   ) {
@@ -624,7 +624,11 @@ class AuthenticationHapiPlugin extends HapiPlugin {
 
   public async isOpenProject(projectId: number) {
     const team = await this.getProjectTeam(projectId);
-    if (team && this.openTeamName && team.name.toLowerCase() === this.openTeamName.toLowerCase()) {
+    if (
+      team &&
+      this.openTeamNames &&
+      this.openTeamNames.indexOf(team.name.toLowerCase()) > -1
+    ) {
       return true;
     }
     return false;

--- a/src/authentication/cached-authentication-hapi-plugin.ts
+++ b/src/authentication/cached-authentication-hapi-plugin.ts
@@ -10,7 +10,7 @@ import {
   adminTeamNameInjectSymbol,
   charlesKnexInjectSymbol,
   fetchInjectSymbol,
-  openTeamNameInjectSymbol,
+  openTeamNamesInjectSymbol,
 } from '../shared/types';
 import {
   authCookieDomainInjectSymbol,
@@ -31,7 +31,7 @@ class CachedAuthenticationHapiPlugin extends AuthenticationHapiPlugin {
     @inject(charlesKnexInjectSymbol) db: Knex,
     @inject(loggerInjectSymbol) logger: Logger,
     @inject(adminTeamNameInjectSymbol) adminTeamName: string,
-    @inject(openTeamNameInjectSymbol) openTeamName: string,
+    @inject(openTeamNamesInjectSymbol) openTeamNames: string[],
     @inject(fetchInjectSymbol) fetch: IFetch,
     @inject(internalHostSuffixesInjectSymbol) internalHostSuffixes: string[],
   ) {
@@ -42,7 +42,7 @@ class CachedAuthenticationHapiPlugin extends AuthenticationHapiPlugin {
       db,
       logger,
       adminTeamName,
-      openTeamName,
+      openTeamNames,
       fetch,
       internalHostSuffixes,
     );

--- a/src/config/config-development.ts
+++ b/src/config/config-development.ts
@@ -1,7 +1,7 @@
 import { Container } from 'inversify';
 
 import { jwtOptionsInjectSymbol } from '../authentication';
-import { adminTeamNameInjectSymbol, openTeamNameInjectSymbol } from '../shared/types';
+import { adminTeamNameInjectSymbol, openTeamNamesInjectSymbol } from '../shared/types';
 import productionConfig from './config-production';
 import { getJwtOptions } from './config-test';
 
@@ -10,11 +10,11 @@ export default (kernel: Container) => {
   if (process.env.INTEGRATION_TEST) {
     console.log('** INTEGRATION TEST MODE **');
     kernel.rebind(jwtOptionsInjectSymbol).toConstantValue(getJwtOptions());
-    const ADMIN_TEAM_NAME = process.env.ADMIN_TEAM_NAME
-      || 'integrationTestAdminTeam';
+    const ADMIN_TEAM_NAME = process.env.ADMIN_TEAM_NAME || 'integrationTestAdminTeam';
     kernel.rebind(adminTeamNameInjectSymbol).toConstantValue(ADMIN_TEAM_NAME);
-    const OPEN_TEAM_NAME = process.env.OPEN_TEAM_NAME
-      || 'integrationTestOpenTeam';
-    kernel.rebind(openTeamNameInjectSymbol).toConstantValue(OPEN_TEAM_NAME);
+    const OPEN_TEAM_NAMES =
+      (process.env.OPEN_TEAM_NAMES && process.env.OPEN_TEAM_NAMES.toLowerCase().split(',')) ||
+      ['integrationTestOpenTeam'];
+    kernel.rebind(openTeamNamesInjectSymbol).toConstantValue(OPEN_TEAM_NAMES);
   }
 };

--- a/src/config/config-development.ts
+++ b/src/config/config-development.ts
@@ -14,7 +14,7 @@ export default (kernel: Container) => {
     kernel.rebind(adminTeamNameInjectSymbol).toConstantValue(ADMIN_TEAM_NAME);
     const OPEN_TEAM_NAMES =
       (process.env.OPEN_TEAM_NAMES && process.env.OPEN_TEAM_NAMES.toLowerCase().split(',')) ||
-      ['integrationTestOpenTeam'];
+      ['integrationtestopenteam'];
     kernel.rebind(openTeamNamesInjectSymbol).toConstantValue(OPEN_TEAM_NAMES);
   }
 };

--- a/src/config/config-production.ts
+++ b/src/config/config-production.ts
@@ -46,7 +46,7 @@ import {
   charlesDbNameInjectSymbol,
   charlesKnexInjectSymbol,
   gitlabKnexInjectSymbol,
-  openTeamNameInjectSymbol,
+  openTeamNamesInjectSymbol,
   postgresKnexInjectSymbol,
 } from '../shared/types';
 
@@ -311,10 +311,10 @@ const EXIT_DELAY = env.EXIT_DELAY ? parseInt(env.EXIT_DELAY, 10) : 15000;
 
 const ADMIN_TEAM_NAME = env.ADMIN_TEAM_NAME || 'lucify';
 
-// Open deployments team-name
+// The names of teams that should have open (= no auth required) deployments
 // --------------
 
-const OPEN_TEAM_NAME = env.OPEN_TEAM_NAME;
+const OPEN_TEAM_NAMES = env.OPEN_TEAM_NAMES && env.OPEN_TEAM_NAMES.toLowerCase().split(',');
 
 // Inversify kernel bindings
 // -------------------------
@@ -348,6 +348,6 @@ export default (kernel: Container) => {
   kernel.bind(authCookieDomainInjectSymbol).toConstantValue(AUTH_COOKIE_DOMAIN);
   kernel.bind(jwtOptionsInjectSymbol).toConstantValue(jwtOptions);
   kernel.bind(adminTeamNameInjectSymbol).toConstantValue(ADMIN_TEAM_NAME);
-  kernel.bind(openTeamNameInjectSymbol).toConstantValue(OPEN_TEAM_NAME);
+  kernel.bind(openTeamNamesInjectSymbol).toConstantValue(OPEN_TEAM_NAMES);
   kernel.bind(internalHostSuffixesInjectSymbol).toConstantValue(INTERNAL_HOST_SUFFIXES.split(','));
 };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -6,4 +6,4 @@ export const charlesDbNameInjectSymbol = Symbol('charles-db-name');
 export const gitlabKnexInjectSymbol = Symbol('gitlab-knex');
 export const postgresKnexInjectSymbol = Symbol('postgres-knex');
 export const adminTeamNameInjectSymbol = Symbol('admin-team-name');
-export const openTeamNameInjectSymbol = Symbol('open-team-name');
+export const openTeamNamesInjectSymbol = Symbol('open-team-names');


### PR DESCRIPTION
This PR changes the `OPEN_TEAM_NAME` environment variable to `OPEN_TEAM_NAMES` and adds support for a comma-separated list of team names.

## Deployment
- [x] Change `OPEN_TEAM_NAME` to `OPEN_TEAM_NAMES`