### PR TITLE
Fix comment removal authorization

### DIFF
--- a/src/authentication/authentication-hapi-plugin-spec.ts
+++ b/src/authentication/authentication-hapi-plugin-spec.ts
@@ -636,25 +636,6 @@ describe('authentication-hapi-plugin', () => {
       expect(plugin.isOpenDeployment).to.have.been.calledOnce;
     });
 
-    // tslint:disable-next-line:max-line-length
-    it('returns false when no credentials are provided, the deployment is open and anonymous access is not allowed', async () => {
-
-      // Arrange
-      const { plugin } = await getPlugin(
-        (p: AuthenticationHapiPlugin) => [
-          sinon.stub(p, p.isOpenDeployment.name)
-            .returns(Promise.resolve(true)),
-        ],
-      );
-
-      // Act
-      const result = await plugin.userHasAccessToDeployment(1, 1, undefined, false);
-
-      // Assert
-      expect(result).to.be.false;
-      expect(plugin.isOpenDeployment).to.not.have.been.called;
-    });
-
     it('returns false when the caller is not authorized and the deployment is not open', async () => {
 
       // Arrange

--- a/src/authentication/authentication-hapi-plugin.ts
+++ b/src/authentication/authentication-hapi-plugin.ts
@@ -589,7 +589,6 @@ class AuthenticationHapiPlugin extends HapiPlugin {
     projectId: number,
     deploymentId: number,
     credentials?: RequestCredentials,
-    allowAnonymousAccessToOpenDeployments = true,
   ) {
     try {
     // If it's AUTHORIZED, it was checked on the top level
@@ -599,7 +598,7 @@ class AuthenticationHapiPlugin extends HapiPlugin {
         (credentials && credentials.authorizationStatus === AuthorizationStatus.AUTHORIZED) ||
         (credentials && credentials.authorizationStatus === AuthorizationStatus.NOT_CHECKED &&
           (await this.userHasAccessToProject(credentials.username!, projectId))) ||
-        (allowAnonymousAccessToOpenDeployments && await this.isOpenDeployment(projectId, deploymentId))
+        (await this.isOpenDeployment(projectId, deploymentId))
       ) {
         return true;
       }

--- a/src/authentication/json-api-authorization-spec.ts
+++ b/src/authentication/json-api-authorization-spec.ts
@@ -303,7 +303,7 @@ describe('authorization for api routes', () => {
       function arrangeCommentRemoval(hasAccess: boolean, isOpen = false) {
         return getServer(
           p => [
-            sinon.stub(p, isOpen ? 'isOpenDeployment' : 'userHasAccessToDeployment')
+            sinon.stub(p, isOpen ? 'isOpenDeployment' : 'userHasAccessToProject')
               .returns(Promise.resolve(hasAccess)),
             sinon.stub(p, 'isAdmin')
               .returns(Promise.resolve(false)),
@@ -321,11 +321,10 @@ describe('authorization for api routes', () => {
         // Arrange
         const { server, authentication, api } = await arrangeCommentRemoval(true);
         // Act
-        const response = await makeRequest(server, '/comments/1', 'DELETE');
+        await makeRequest(server, '/comments/1', 'DELETE');
         // Assert
-        expect(response).to.exist;
         expect(api.getComment).to.have.been.calledOnce;
-        expect(authentication.userHasAccessToDeployment).to.have.been.calledOnce;
+        expect(authentication.userHasAccessToProject).to.have.been.calledOnce;
         expect(api.deleteCommentHandler).to.have.been.calledOnce;
       });
       it('should not allow deleting a comment for a deployment in an unauthorized project', async () => {
@@ -335,22 +334,19 @@ describe('authorization for api routes', () => {
         const response = await makeRequest(server, '/comments/1', 'DELETE');
         // Assert
         expect(api.getComment).to.have.been.calledOnce;
-        expect(authentication.userHasAccessToDeployment).to.have.been.calledOnce;
+        expect(authentication.userHasAccessToProject).to.have.been.calledOnce;
         expect(api.deleteCommentHandler).to.not.have.been.called;
         expect(response.statusCode).to.eq(401);
       });
       it('should not allow deleting a comment for an open deployment without authentication', async () => {
         // Arrange
-        const { server, authentication, api } = await arrangeCommentRemoval(true, true);
+        const { server } = await arrangeCommentRemoval(false, true);
         // Act
         const response = await server.inject({
           method: 'DELETE',
           url: 'http://foo.com/comments/1',
         });
         // Assert
-        expect(api.getComment).to.have.been.calledOnce;
-        expect(authentication.isOpenDeployment).to.not.have.been.called;
-        expect(api.deleteCommentHandler).to.not.have.been.called;
         expect(response.statusCode).to.eq(401);
       });
 

--- a/src/json-api/json-api-hapi-plugin.ts
+++ b/src/json-api/json-api-hapi-plugin.ts
@@ -503,7 +503,7 @@ export class JsonApiHapiPlugin {
       },
       config: {
         bind: this,
-        auth: openAuth,
+        auth: STRATEGY_ROUTELEVEL_USER_HEADER,
         pre: [
           {
             method: this.authorizeCommentRemoval,
@@ -860,7 +860,7 @@ export class JsonApiHapiPlugin {
         return reply(Boom.badRequest('Invalid deployment id'));
       }
       const { projectId, deploymentId } = parsed;
-      if (await request.userHasAccessToDeployment(projectId, deploymentId, request.auth.credentials, false)) {
+      if (await request.userHasAccessToDeployment(projectId, deploymentId, request.auth.credentials)) {
         return reply(commentId);
       }
     } catch (exception) {

--- a/src/server/hapi.ts
+++ b/src/server/hapi.ts
@@ -25,7 +25,6 @@ declare module 'hapi' {
       projectId: number,
       deploymentId: number,
       credentials?: RequestCredentials,
-      allowAnonymousAccessToOpenDeployments?: boolean,
     ) => Promise<boolean>;
     isOpenDeployment: (projectId: number, deploymentId: number) => Promise<boolean>;
     getProjectTeam: (projectId: number) => Promise<{id: number, name: string}>;


### PR DESCRIPTION
The error was that with STRATEGY_TOPLEVEL_USER_HEADER (the previous strategy), we tried to authorize on the top level, but since the comment deletion request doesn't contain a project id, it returned ' NOT_AUTHORIZED'. This PR changes the strategy to STRATEGY_ROUTELEVEL_USER_HEADER, which returns 'NOT_CHECKED' on the top level.

This PR also removes a now obsolete parameter from the request decorator 'userHasAccessToDeployment'. The parameter was only used by the faulty implementation for comment removal authorization.