### PR TITLE
Fix comment creation authorization

### DIFF
--- a/src/authentication/authentication-hapi-plugin.ts
+++ b/src/authentication/authentication-hapi-plugin.ts
@@ -591,10 +591,10 @@ class AuthenticationHapiPlugin extends HapiPlugin {
     credentials?: RequestCredentials,
   ) {
     try {
-    // If it's AUTHORIZED, it was checked on the top level
-    // If it's NOT_CHECKED, we need to check here
-    // Otherwise only allow access to open deployments
-    if (
+      // If it's AUTHORIZED, it was checked on the top level
+      // If it's NOT_CHECKED, we need to check here
+      // Otherwise only allow access to open deployments
+      if (
         (credentials && credentials.authorizationStatus === AuthorizationStatus.AUTHORIZED) ||
         (credentials && credentials.authorizationStatus === AuthorizationStatus.NOT_CHECKED &&
           (await this.userHasAccessToProject(credentials.username!, projectId))) ||

--- a/src/authentication/json-api-authorization-spec.ts
+++ b/src/authentication/json-api-authorization-spec.ts
@@ -36,36 +36,25 @@ async function getServer(
   };
 }
 
-type AuthorizationMethod =
-  'userHasAccessToProject' |
-  'userHasAccessToTeam' |
-  'userHasAccessToDeployment' |
-  'isOpenDeployment';
-const authorizationMethods = [
-  'userHasAccessToProject',
-  'userHasAccessToTeam',
-  'userHasAccessToDeployment',
-  'isOpenDeployment',
-];
+type AuthorizationMethod = 'userHasAccessToProject' | 'userHasAccessToTeam';
 
 function arrange(
   authorizationMethod: AuthorizationMethod,
   hasAccess: boolean,
   handler: string,
   isAdmin: boolean = false,
+  isOpenDeployment: boolean = false,
   deploymentId?: number,
 ) {
   return getServer(
-    (plugin: AuthenticationHapiPlugin) => authorizationMethods
-      .filter(m => !(m === 'userHasAccessToDeployment' && authorizationMethod === 'isOpenDeployment'))
-      .map(
-        m => sinon.stub(plugin, m)
-          .returns(Promise.resolve(m === authorizationMethod ? hasAccess : false)),
-      )
-      .concat(
-        sinon.stub(plugin, 'isAdmin')
+    (plugin: AuthenticationHapiPlugin) => [
+      sinon.stub(plugin, authorizationMethod)
+        .returns(Promise.resolve(hasAccess)),
+      sinon.stub(plugin, 'isAdmin')
           .returns(Promise.resolve(isAdmin)),
-      ),
+      sinon.stub(plugin, 'isOpenDeployment')
+          .returns(Promise.resolve(isOpenDeployment)),
+    ],
     (p: JsonApiHapiPlugin) => [
       sinon.stub(p, handler)
         .yields(200)
@@ -211,7 +200,7 @@ describe('authorization for api routes', () => {
       it('should allow fetching comments for a deployment in an authorized project', async () => {
         // Arrange
         const { server, authentication, api } = await arrange(
-          'userHasAccessToDeployment',
+          'userHasAccessToProject',
           true,
           'getDeploymentCommentsHandler',
         );
@@ -219,13 +208,13 @@ describe('authorization for api routes', () => {
         await makeRequest(server, '/comments/deployment/1-1', 'GET');
 
         // Assert
-        expect(authentication.userHasAccessToDeployment).to.have.been.calledOnce;
+        expect(authentication.userHasAccessToProject).to.have.been.calledOnce;
         expect(api.getDeploymentCommentsHandler).to.have.been.calledOnce;
       });
       it('should not allow fetching comments for a deployment in an unauthorized project', async () => {
         // Arrange
         const { server, authentication, api } = await arrange(
-          'userHasAccessToDeployment',
+          'userHasAccessToProject',
           false,
           'getDeploymentCommentsHandler',
         );
@@ -233,13 +222,18 @@ describe('authorization for api routes', () => {
         const response = await makeRequest(server, '/comments/deployment/1-1', 'GET');
 
         expect(response.statusCode).to.eq(401);
-        expect(authentication.userHasAccessToDeployment).to.have.been.calledOnce;
+        expect(authentication.userHasAccessToProject).to.have.been.calledOnce;
         expect(api.getDeploymentCommentsHandler).to.not.have.been.called;
       });
       it('should allow fetching comments for an open deployment without authentication', async () => {
         // Arrange
-        const { server, authentication, api } = await arrange('isOpenDeployment', true, 'getDeploymentCommentsHandler');
-        // Act
+        const { server, authentication, api } = await arrange(
+          'userHasAccessToProject',
+          false,
+          'getDeploymentCommentsHandler',
+          false,
+          true,
+        );        // Act
         await server.inject({
           method: 'GET',
           url: 'http://foo.com/comments/deployment/1-1',
@@ -264,7 +258,7 @@ describe('authorization for api routes', () => {
       it('should allow creating a comment for a deployment in an authorized project', async () => {
         // Arrange
         const { server, authentication, api } = await arrange(
-          'userHasAccessToDeployment',
+          'userHasAccessToProject',
           true,
           'postCommentHandler',
         );
@@ -272,22 +266,28 @@ describe('authorization for api routes', () => {
         await makeRequest(server, '/comments', 'POST', payload);
 
         // Assert
-        expect(authentication.userHasAccessToDeployment).to.have.been.calledOnce;
+        expect(authentication.userHasAccessToProject).to.have.been.calledOnce;
         expect(api.postCommentHandler).to.have.been.calledOnce;
       });
       it('should not allow creating a comment for a deployment in an unauthorized project', async () => {
         // Arrange
-        const { server, authentication, api } = await arrange('userHasAccessToDeployment', false, 'postCommentHandler');
+        const { server, authentication, api } = await arrange('userHasAccessToProject', false, 'postCommentHandler');
         // Act
         const response = await makeRequest(server, '/comments', 'POST', payload);
         // Assert
         expect(response.statusCode).to.eq(401);
-        expect(authentication.userHasAccessToDeployment).to.have.been.calledOnce;
+        expect(authentication.userHasAccessToProject).to.have.been.calledOnce;
         expect(api.postCommentHandler).to.not.have.been.called;
       });
       it('should allow creating a comment for an open deployment without authentication', async () => {
         // Arrange
-        const { server, authentication, api } = await arrange('isOpenDeployment', true, 'postCommentHandler');
+        const { server, authentication, api } = await arrange(
+          'userHasAccessToProject',
+          false,
+          'postCommentHandler',
+          false,
+          true,
+        );
         // Act
         await server.inject({
           method: 'POST',
@@ -558,7 +558,7 @@ describe('authorization for api routes', () => {
         it('should allow fetching the preview for a deployment in an authorized project', async () => {
           // Arrange
           const { server, authentication, api, tokenGenerator } = await arrange(
-            'userHasAccessToDeployment',
+            'userHasAccessToProject',
             true,
             'getPreviewHandler',
           );
@@ -567,13 +567,13 @@ describe('authorization for api routes', () => {
           await makeRequest(server, `/preview/deployment/1-1/${token}`, 'GET');
 
           // Assert
-          expect(authentication.userHasAccessToDeployment).to.have.been.calledOnce;
+          expect(authentication.userHasAccessToProject).to.have.been.calledOnce;
           expect(api.getPreviewHandler).to.have.been.calledOnce;
         });
         it('should not allow fetching the preview for a deployment in an unauthorized project', async () => {
           // Arrange
           const { server, authentication, api, tokenGenerator } = await arrange(
-            'userHasAccessToDeployment',
+            'userHasAccessToProject',
             false,
             'getPreviewHandler',
           );
@@ -582,15 +582,17 @@ describe('authorization for api routes', () => {
           const response = await makeRequest(server, `/preview/deployment/1-1/${token}`, 'GET');
 
           expect(response.statusCode).to.eq(401);
-          expect(authentication.userHasAccessToDeployment).to.have.been.calledOnce;
+          expect(authentication.userHasAccessToProject).to.have.been.calledOnce;
           expect(api.getPreviewHandler).to.not.have.been.called;
         });
         it('should allow fetching the preview for an open deployment without authentication', async () => {
           // Arrange
           const { server, authentication, api, tokenGenerator } = await arrange(
-            'isOpenDeployment',
+            'userHasAccessToProject',
             true,
             'getPreviewHandler',
+            false,
+            true,
           );
           const token = tokenGenerator.deploymentToken(1, 1);
 
@@ -608,9 +610,10 @@ describe('authorization for api routes', () => {
         it('should allow fetching the preview for a deployment in an authorized project', async () => {
           // Arrange
           const { server, authentication, api, tokenGenerator } = await arrange(
-            'userHasAccessToDeployment',
+            'userHasAccessToProject',
             true,
             'getPreviewHandler',
+            false,
             false,
             2,
           );
@@ -619,16 +622,17 @@ describe('authorization for api routes', () => {
           await makeRequest(server, `/preview/project/1/${token}`, 'GET');
 
           // Assert
-          expect(authentication.userHasAccessToDeployment).to.have.been.calledOnce;
+          expect(authentication.userHasAccessToProject).to.have.been.calledOnce;
           expect(api.getLatestSuccessfulDeploymentIdForProject).to.have.been.calledOnce;
           expect(api.getPreviewHandler).to.have.been.calledOnce;
         });
         it('should not allow fetching the preview for a deployment in an unauthorized project', async () => {
           // Arrange
           const { server, authentication, api, tokenGenerator } = await arrange(
-            'userHasAccessToDeployment',
+            'userHasAccessToProject',
             false,
             'getPreviewHandler',
+            false,
             false,
             2,
           );
@@ -639,16 +643,17 @@ describe('authorization for api routes', () => {
 
           expect(response.statusCode).to.eq(401);
           expect(api.getLatestSuccessfulDeploymentIdForProject).to.have.been.calledOnce;
-          expect(authentication.userHasAccessToDeployment).to.have.been.calledOnce;
+          expect(authentication.userHasAccessToProject).to.have.been.calledOnce;
           expect(api.getPreviewHandler).to.not.have.been.called;
         });
         it('should allow fetching the preview for an open deployment without authentication', async () => {
           // Arrange
           const { server, authentication, api, tokenGenerator } = await arrange(
-            'isOpenDeployment',
+            'userHasAccessToProject',
             true,
             'getPreviewHandler',
             false,
+            true,
             2,
           );
           const token = tokenGenerator.projectToken(1);
@@ -665,9 +670,11 @@ describe('authorization for api routes', () => {
         it('should return 404 when deployment not found', async () => {
           // Arrange
           const { server, tokenGenerator } = await arrange(
-            'isOpenDeployment',
+            'userHasAccessToProject',
             true,
             'getPreviewHandler',
+            false,
+            false,
             undefined,
           );
           const token = tokenGenerator.projectToken(1);
@@ -684,9 +691,10 @@ describe('authorization for api routes', () => {
         it('should allow fetching the preview for a deployment in an authorized project', async () => {
           // Arrange
           const { server, authentication, api, tokenGenerator } = await arrange(
-            'userHasAccessToDeployment',
+            'userHasAccessToProject',
             true,
             'getPreviewHandler',
+            false,
             false,
             2,
           );
@@ -695,16 +703,17 @@ describe('authorization for api routes', () => {
           await makeRequest(server, `/preview/branch/1-foo-bar/${token}`, 'GET');
 
           // Assert
-          expect(authentication.userHasAccessToDeployment).to.have.been.calledOnce;
+          expect(authentication.userHasAccessToProject).to.have.been.calledOnce;
           expect(api.getLatestSuccessfulDeploymentIdForBranch).to.have.been.calledOnce;
           expect(api.getPreviewHandler).to.have.been.calledOnce;
         });
         it('should not allow fetching the preview for a deployment in an unauthorized project', async () => {
           // Arrange
           const { server, authentication, api, tokenGenerator } = await arrange(
-            'userHasAccessToDeployment',
+            'userHasAccessToProject',
             false,
             'getPreviewHandler',
+            false,
             false,
             2,
           );
@@ -715,16 +724,17 @@ describe('authorization for api routes', () => {
 
           expect(response.statusCode).to.eq(401);
           expect(api.getLatestSuccessfulDeploymentIdForBranch).to.have.been.calledOnce;
-          expect(authentication.userHasAccessToDeployment).to.have.been.calledOnce;
+          expect(authentication.userHasAccessToProject).to.have.been.calledOnce;
           expect(api.getPreviewHandler).to.not.have.been.called;
         });
         it('should allow fetching the preview for an open deployment without authentication', async () => {
           // Arrange
           const { server, authentication, api, tokenGenerator } = await arrange(
-            'isOpenDeployment',
+            'userHasAccessToProject',
             true,
             'getPreviewHandler',
             false,
+            true,
             2,
           );
           const token = tokenGenerator.branchToken(1, 'foo-bar');
@@ -741,9 +751,11 @@ describe('authorization for api routes', () => {
         it('returns 404 when deployment is not found', async () => {
           // Arrange
           const { server, tokenGenerator } = await arrange(
-            'isOpenDeployment',
+            'userHasAccessToProject',
             true,
             'getPreviewHandler',
+            false,
+            false,
             undefined,
           );
           const token = tokenGenerator.branchToken(1, 'foo-bar');

--- a/src/authentication/json-api-authorization-spec.ts
+++ b/src/authentication/json-api-authorization-spec.ts
@@ -233,7 +233,8 @@ describe('authorization for api routes', () => {
           'getDeploymentCommentsHandler',
           false,
           true,
-        );        // Act
+        );
+        // Act
         await server.inject({
           method: 'GET',
           url: 'http://foo.com/comments/deployment/1-1',

--- a/src/json-api/json-api-hapi-plugin.ts
+++ b/src/json-api/json-api-hapi-plugin.ts
@@ -524,7 +524,10 @@ export class JsonApiHapiPlugin {
       },
       config: {
         bind: this,
-        auth: openAuth,
+        auth: {
+          mode: 'try',
+          strategies: [STRATEGY_ROUTELEVEL_USER_HEADER],
+        },
         pre: [
           {
             method: this.authorizeCommentCreation,
@@ -839,7 +842,7 @@ export class JsonApiHapiPlugin {
         return reply(Boom.badRequest('Invalid deployment id'));
       }
       if (await request.userHasAccessToDeployment(parsed.projectId, deploymentId, request.auth.credentials)) {
-        return reply(parsed.deploymentId);
+         return reply(parsed.deploymentId);
       }
     } catch (exception) {
       // TODO: log exception

--- a/src/json-api/json-api-hapi-plugin.ts
+++ b/src/json-api/json-api-hapi-plugin.ts
@@ -109,6 +109,8 @@ export class JsonApiHapiPlugin {
 
     server.ext('onPreResponse', onPreResponse.bind(undefined, server));
 
+    // Open auth can only be used if the request contains a project, branch or
+    // team ID, otherwise it will fail.
     const openAuth = {
       mode: 'try',
       strategies: [STRATEGY_TOPLEVEL_USER_HEADER],
@@ -524,6 +526,8 @@ export class JsonApiHapiPlugin {
       },
       config: {
         bind: this,
+        // Open auth cannot be used here because the request does not contain
+        // a deployment, branch or team ID.
         auth: {
           mode: 'try',
           strategies: [STRATEGY_ROUTELEVEL_USER_HEADER],

--- a/src/json-api/json-api-hapi-plugin.ts
+++ b/src/json-api/json-api-hapi-plugin.ts
@@ -842,7 +842,7 @@ export class JsonApiHapiPlugin {
         return reply(Boom.badRequest('Invalid deployment id'));
       }
       if (await request.userHasAccessToDeployment(parsed.projectId, deploymentId, request.auth.credentials)) {
-         return reply(parsed.deploymentId);
+        return reply(parsed.deploymentId);
       }
     } catch (exception) {
       // TODO: log exception


### PR DESCRIPTION
The route had an incorrect authentication strategy. Changed to
```javascript
{
  mode: 'try',
  strategies: [STRATEGY_ROUTELEVEL_USER_HEADER],
}
```
meaning we try to authenticate with the header, but let the request continue in any case. We then check authorization on the route level. 

This has the desired effect of allowing open commenting on open deployments but still checking for proper authorization on non-open ones.

This PR also includes a refactoring of the authorization spec for json-api.

Based on #199, remember to change the base before merging.
