### PR TITLE
Use email if no name defined as author name in Slack notifications

### DIFF
--- a/src/notification/slack-notify.ts
+++ b/src/notification/slack-notify.ts
@@ -19,7 +19,7 @@ export function getMessage(
   const message: SlackAttachment = {
     fallback,
     color: '#40C1AC',
-    author_name: author.name,
+    author_name: author.name || author.email,
     author_icon: gravatar.url(author.email, undefined, false),
     title: comment ? 'New comment' : 'New preview',
     title_link: previewUrl,


### PR DESCRIPTION
If the name is missing, Slack won't show an avatar.