### PR TITLE
Realtime token

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@types/fs-extra": "^2.1.0",
     "@types/fs-promise": "^1.0.3",
     "@types/gravatar": "^1.4.28",
-    "@types/hapi": "^16.0.3",
+    "@types/hapi": "16.0.3",
     "@types/joi": "^10.3.0",
     "@types/jsonwebtoken": "^7.2.0",
     "@types/knex": "0.0.46",

--- a/package.json
+++ b/package.json
@@ -87,9 +87,9 @@
     "sinon": "^2.1.0",
     "sinon-chai": "^2.9.0",
     "sqlite3": "^3.1.8",
-    "ts-node": "^3.0.2",
-    "tslint": "^5.1.0",
-    "typescript": "^2.3.1"
+    "ts-node": "^3.0.4",
+    "tslint": "^5.2.0",
+    "typescript": "^2.3.2"
   },
   "scripts": {
     "clean-test": "rm -rf dist && npm run-script transpile && mocha ./dist/**/*-spec.js",

--- a/src/authentication/realtime-authorization-spec.ts
+++ b/src/authentication/realtime-authorization-spec.ts
@@ -1,0 +1,141 @@
+import { expect, use } from 'chai';
+import { Server } from 'hapi';
+import 'reflect-metadata';
+import * as sinon from 'sinon';
+import * as sinonChai from 'sinon-chai';
+use(sinonChai);
+
+import { bootstrap } from '../config';
+import { getSignedAccessToken } from '../config/config-test';
+import { RealtimeHapiPlugin } from '../realtime';
+import { getTestServer } from '../server/hapi';
+import { MethodStubber, stubber } from '../shared/test';
+import TokenGenerator from '../shared/token-generator';
+import AuthenticationHapiPlugin from './authentication-hapi-plugin';
+import { generateTeamToken } from './team-token';
+
+const validAccessToken = getSignedAccessToken('idp|12345678', generateTeamToken(), 'foo@bar.com');
+async function getServer(
+  authenticationStubber: MethodStubber<AuthenticationHapiPlugin>,
+) {
+  const kernel = bootstrap('test');
+  kernel.rebind(AuthenticationHapiPlugin.injectSymbol).to(AuthenticationHapiPlugin);
+  kernel.rebind(RealtimeHapiPlugin.injectSymbol).to(RealtimeHapiPlugin);
+  const plugin = stubber<RealtimeHapiPlugin>(
+    p => sinon.stub(p, p.deploymentHandler.name)
+        .yields(200)
+        .returns(Promise.resolve(true)),
+    RealtimeHapiPlugin.injectSymbol,
+    kernel,
+  );
+
+  const authenticationPlugin = stubber(authenticationStubber, AuthenticationHapiPlugin.injectSymbol, kernel);
+  const server = await getTestServer(true, authenticationPlugin.instance, plugin.instance);
+  const tokenGenerator = kernel.get<TokenGenerator>(TokenGenerator.injectSymbol);
+
+  return {
+    server,
+    authentication: authenticationPlugin.instance,
+    tokenGenerator,
+  };
+}
+
+function arrange(
+  hasAccessToProject: boolean,
+  isAdmin = false,
+  isOpenDeployment = false,
+) {
+  return getServer(
+    (p: AuthenticationHapiPlugin) => {
+      return [
+        sinon.stub(p, p.userHasAccessToProject.name)
+          .returns(Promise.resolve(hasAccessToProject)),
+        sinon.stub(p, p.isAdmin.name)
+          .returns(Promise.resolve(isAdmin)),
+        sinon.stub(p, p.isOpenDeployment.name)
+          .returns(Promise.resolve(isOpenDeployment)),
+        sinon.stub(p, p.getProjectTeam.name)
+          .returns(Promise.resolve({id: 1, name: 'foo'})),
+      ];
+    },
+  );
+}
+
+describe('authorization for deployment events', () => {
+  describe('authenticated user', () => {
+    function makeRequest(server: Server, token: string) {
+      return server.inject({
+        method: 'GET',
+        url: `/events/deployment/1-1/${token}?token=${validAccessToken}`,
+      });
+    }
+    it('should allow accessing authorized deployments', async () => {
+      // Arrange
+      const { server, authentication, tokenGenerator } = await arrange(true);
+      // Act
+      const response = await makeRequest(server, tokenGenerator.deploymentToken(1, 1));
+      // Assert
+      expect(response.statusCode, response.payload).to.eq(200);
+      expect(authentication.userHasAccessToProject).to.have.been.calledOnce;
+    });
+    it('should allow accessing open deployments', async () => {
+      // Arrange
+      const { server, authentication, tokenGenerator } = await arrange(true, false, true);
+      // Act
+      const response = await makeRequest(server, tokenGenerator.deploymentToken(1, 1));
+      // Assert
+      expect(response.statusCode).to.eq(200);
+      expect(authentication.userHasAccessToProject).to.have.been.calledOnce;
+    });
+    it('should not allow accessing unauthorized deployments', async () => {
+      // Arrange
+      const { server, authentication, tokenGenerator } = await arrange(false);
+      // Act
+      const response = await makeRequest(server, tokenGenerator.deploymentToken(1, 1));
+      // Assert
+      expect(response.statusCode).to.eq(404);
+      expect(authentication.userHasAccessToProject).to.have.been.calledOnce;
+    });
+    it('should not allow accessing when token is invalid', async () => {
+      // Arrange
+      const { server, authentication } = await arrange(true);
+      // Act
+      const response = await makeRequest(server, 'foobar');
+      // Assert
+      expect(response.statusCode).to.eq(403);
+      expect(authentication.userHasAccessToProject).to.have.been.calledOnce;
+    });
+  });
+  describe('unauthenticated user', () => {
+    function makeRequest(server: Server, token: string) {
+      return server.inject({
+        method: 'GET',
+        url: `/events/deployment/1-1/${token}`,
+      });
+    }
+    it('should not allow accessing non-open deployments', async () => {
+      // Arrange
+      const { server, tokenGenerator } = await arrange(false);
+      // Act
+      const response = await makeRequest(server, tokenGenerator.deploymentToken(1, 1));
+      // Assert
+      expect(response.statusCode, response.payload).to.eq(404);
+    });
+    it('should allow accessing open deployments', async () => {
+      // Arrange
+      const { server, tokenGenerator } = await arrange(false, false, true);
+      // Act
+      const response = await makeRequest(server, tokenGenerator.deploymentToken(1, 1));
+      // Assert
+      expect(response.statusCode).to.eq(200);
+    });
+    it('should not allow accessing when token is invalid', async () => {
+      // Arrange
+      const { server } = await arrange(false, false, true);
+      // Act
+      const response = await makeRequest(server, 'foobar');
+      // Assert
+      expect(response.statusCode).to.eq(403);
+    });
+  });
+});

--- a/src/project/project-module.ts
+++ b/src/project/project-module.ts
@@ -184,7 +184,7 @@ export default class ProjectModule {
     return projects.map(item => item.id);
   }
 
-   public async getProjectsUsingPath(path: string): Promise<MinardProject[] | null> {
+  public async getProjectsUsingPath(path: string): Promise<MinardProject[] | null> {
     try {
       const projects = await this.gitlab.fetchJson<Project[]>(path);
       if (!projects) {

--- a/tslint.json
+++ b/tslint.json
@@ -4,7 +4,7 @@
     "quotemark": [true, "single", "avoid-escape", "jsx-double"],
     "no-var-requires": false,
     "object-literal-sort-keys": false,
-    "no-console": [],
+    "no-console": [false],
     "member-ordering": [false],
     "arrow-parens": false,
     "array-type": [true, "array"],
@@ -15,7 +15,8 @@
     "space-before-function-paren": false,
     "no-angle-bracket-type-assertion": false,
     "no-empty-interface": false,
-    "no-unused-expression": false
+    "no-unused-expression": false,
+    "no-object-literal-type-assertion": [false]
   },
   "rulesDirectory": []
 }


### PR DESCRIPTION
Adds token validation to deployment events endpoint. Similar to the preview endpoint authorization wise, this prevents anonymous users from guessing urls.

The endpoint is now `GET /events/deployment/{deploymentId}/{token}`.
Realtime endpoints were previously lacking authorization unit tests, which are now also implemented in this PR.
