### PR TITLE
Ensure usernames don't start with a number

### DIFF
--- a/src/authentication/authentication-hapi-plugin-spec.ts
+++ b/src/authentication/authentication-hapi-plugin-spec.ts
@@ -24,7 +24,7 @@ import { AuthorizationStatus, RequestCredentials } from './types';
 const defaultTeamTokenString = generateTeamToken();
 expect(defaultTeamTokenString.length).to.equal(teamTokenLength);
 const defaultEmail = 'foo@bar.com';
-const defaultSub = 'idp|12345678';
+const defaultSub = 'auth0|12345678';
 
 const validAccessToken = getSignedAccessToken(defaultSub, defaultTeamTokenString, defaultEmail);
 const invalidAccessToken = `${validAccessToken}a`;

--- a/src/authentication/authentication-hapi-plugin-spec.ts
+++ b/src/authentication/authentication-hapi-plugin-spec.ts
@@ -16,6 +16,7 @@ import {
   accessTokenCookieSettings,
   default as AuthenticationHapiPlugin,
   generatePassword,
+  sanitizeSubClaim,
 } from './authentication-hapi-plugin';
 import { generateAndSaveTeamToken, generateTeamToken, teamTokenLength } from './team-token';
 import { initializeTeamTokenTable } from './team-token-spec';
@@ -803,6 +804,45 @@ describe('authentication-hapi-plugin', () => {
       return resultPromise
         .then(_ => expect.fail(), error => expect(error.isBoom).to.be.true);
     });
+  });
+  describe('sanitizeSubClaim', () => {
+    it('sanitizes regular sub claims', async () => {
+
+      // Arrange
+      const sub = 'auth0|foo';
+
+      // Act
+      const sanitized = sanitizeSubClaim(sub);
+
+      // Assert
+      expect(sanitized).to.eq('auth0-foo');
+    });
+    it('sanitizes non-interactive sub claims', async () => {
+
+      // Arrange
+      const sub = 'foo@clients';
+
+      // Act
+      const sanitized = sanitizeSubClaim(sub);
+
+      // Assert
+      expect(sanitized).to.eq('clients-foo');
+    });
+    it('throws is not correct format', async () => {
+
+      // Arrange
+      const case1 = () => sanitizeSubClaim('foo');
+      const case2 = () => sanitizeSubClaim('1foo');
+      const case3 = () => sanitizeSubClaim('auth0foo|43dfdfg');
+      const case4 = () => sanitizeSubClaim('clients@234234');
+
+      // Assert
+      expect(case1).to.throw;
+      expect(case2).to.throw;
+      expect(case3).to.throw;
+      expect(case4).to.throw;
+    });
+
   });
 });
 

--- a/src/authentication/json-api-authorization-spec.ts
+++ b/src/authentication/json-api-authorization-spec.ts
@@ -14,7 +14,7 @@ import TokenGenerator from '../shared/token-generator';
 import AuthenticationHapiPlugin from './authentication-hapi-plugin';
 import { generateTeamToken } from './team-token';
 
-const validAccessToken = getSignedAccessToken('idp|12345678', generateTeamToken(), 'foo@bar.com');
+const validAccessToken = getSignedAccessToken('auth0|12345678', generateTeamToken(), 'foo@bar.com');
 const makeRequest = makeRequestWithAuthentication(validAccessToken);
 
 async function getServer(

--- a/src/authentication/raw-deployment-authorization-spec.ts
+++ b/src/authentication/raw-deployment-authorization-spec.ts
@@ -13,7 +13,7 @@ import { MethodStubber, stubber } from '../shared/test';
 import AuthenticationHapiPlugin from './authentication-hapi-plugin';
 import { generateTeamToken } from './team-token';
 
-const validAccessToken = getSignedAccessToken('idp|12345678', generateTeamToken(), 'foo@bar.com');
+const validAccessToken = getSignedAccessToken('auth0|12345678', generateTeamToken(), 'foo@bar.com');
 const deploymentDomain = 'deployment.foo.com';
 const validDeploymentUrl = `http://master-abcdef-1-1.${deploymentDomain}`;
 async function getServer(

--- a/src/authentication/realtime-authorization-spec.ts
+++ b/src/authentication/realtime-authorization-spec.ts
@@ -14,7 +14,7 @@ import TokenGenerator from '../shared/token-generator';
 import AuthenticationHapiPlugin from './authentication-hapi-plugin';
 import { generateTeamToken } from './team-token';
 
-const validAccessToken = getSignedAccessToken('idp|12345678', generateTeamToken(), 'foo@bar.com');
+const validAccessToken = getSignedAccessToken('auth0|12345678', generateTeamToken(), 'foo@bar.com');
 async function getServer(
   authenticationStubber: MethodStubber<AuthenticationHapiPlugin>,
 ) {

--- a/src/config/config-test.ts
+++ b/src/config/config-test.ts
@@ -10,7 +10,6 @@ import {
   jwtOptionsInjectSymbol,
   teamTokenClaimKey,
 } from '../authentication';
-import { sanitizeUsername } from '../authentication/authentication-hapi-plugin';
 import AuthenticationModule from '../authentication/authentication-module';
 import { eventStoreConfigInjectSymbol } from '../event-bus';
 import { JsonApiHapiPlugin } from '../json-api';
@@ -82,7 +81,6 @@ export function getAccessToken(sub: string, teamToken?: string, email?: string):
     exp: Math.round(Date.now() / 1000) + 3600,
     iat: Math.round(Date.now() / 1000) - 3600,
     email: email || 'foo@bar.com',
-    username: sanitizeUsername(sub),
   };
   if (teamToken) {
     payload = { ...payload, [teamTokenClaimKey]: teamToken };


### PR DESCRIPTION
Auth0 non-interactive clients have a sub claim with the format `{clientId}@clients`, where `clientId` is an opaque string which can start with a number. Transforming the sub claim to a username `{clientId}-clients` is not a good idea, since if `clientId` happens to start with a number, GitLab might end up parsing a username as a numeric user-id. This PR changes the username transformation into `clients-{clientId}`.

This PR also adds a check ensuring that users can only validly belong to a single team.