### PR TITLE
Team scoped notification configuration listing

### DIFF
--- a/docs/api/api-notification.md
+++ b/docs/api/api-notification.md
@@ -19,6 +19,65 @@ Name|Type|Description
 `hipchat-room-id`|string|Hipchat room id (only for `hipchat`)
 `slack-webhook-url`|string|Slack webhook URL (only for `slack`)
 
+## Get team-scoped notification configurations
+
+### Request
+
+- Method: `GET`
+- URL: `/api/teams/:teamId/relationships/notification`
+
+### Response
+
+Returns an array of JSON API objects, for example
+
+```json
+[
+  {
+    "data": {
+      "id": 5,
+      "type": "notifications",
+      "attributes": {
+        "type": "hipchat",
+        "teamId": ":teamId",
+        "hipchatAuthToken": "[YOUR_HIP_CHAT_AUTH_TOKEN]",
+        "hipchatRoomId": "[YOUR_HIP_CHAT_ROOM_ID]"
+      }
+    }
+  }
+]
+```
+
+The notification type related attributes are described below in *Add notification configuration*.
+
+## Get project-scoped notification configurations
+
+### Request
+
+- Method: `GET`
+- URL: `/api/projects/:projectId/relationships/notification`
+
+### Response
+
+Returns an array of JSON API objects, for example
+
+```json
+[
+  {
+    "data": {
+      "id": 4,
+      "type": "notifications",
+      "attributes": {
+        "type": "flowdock",
+        "projectId": ":projectId",
+        "flowToken": "[FLOW_TOKEN]"
+      }
+    }
+  }
+]
+```
+
+The notification type related attributes are described below.
+
 ## Add notification configuration
 
 ### Request

--- a/docs/api/api-notification.md
+++ b/docs/api/api-notification.md
@@ -28,23 +28,26 @@ Name|Type|Description
 
 ### Response
 
-Returns an array of JSON API objects, for example
+Returns a JSON API response object, where the `data` key is an array of JSON API entities, for example
 
 ```json
-[
-  {
-    "data": {
-      "id": 5,
-      "type": "notifications",
-      "attributes": {
-        "type": "hipchat",
-        "teamId": ":teamId",
-        "hipchatAuthToken": "[YOUR_HIP_CHAT_AUTH_TOKEN]",
-        "hipchatRoomId": "[YOUR_HIP_CHAT_ROOM_ID]"
+{
+  "data":
+  [
+    {
+      "data": {
+        "id": 5,
+        "type": "notifications",
+        "attributes": {
+          "type": "hipchat",
+          "teamId": ":teamId",
+          "hipchatAuthToken": "[YOUR_HIP_CHAT_AUTH_TOKEN]",
+          "hipchatRoomId": "[YOUR_HIP_CHAT_ROOM_ID]"
+        }
       }
     }
-  }
-]
+  ]
+}
 ```
 
 The notification type related attributes are described below in *Add notification configuration*.
@@ -58,23 +61,27 @@ The notification type related attributes are described below in *Add notificatio
 
 ### Response
 
-Returns an array of JSON API objects, for example
+Returns a JSON API response object, where the `data` key is an array of JSON API entities, for example
 
 ```json
-[
-  {
-    "data": {
-      "id": 4,
-      "type": "notifications",
-      "attributes": {
-        "type": "flowdock",
-        "projectId": ":projectId",
-        "flowToken": "[FLOW_TOKEN]"
+{
+  "data":
+  [
+    {
+      "data": {
+        "id": 4,
+        "type": "notifications",
+        "attributes": {
+          "type": "flowdock",
+          "projectId": ":projectId",
+          "flowToken": "[FLOW_TOKEN]"
+        }
       }
     }
-  }
-]
+  ]
+}
 ```
+
 
 The notification type related attributes are described below.
 

--- a/src/integration-test/charles-client.ts
+++ b/src/integration-test/charles-client.ts
@@ -193,6 +193,20 @@ export default class CharlesClient {
    * NOTIFICATION
    */
 
+  public async getTeamNotificationConfigurations(teamId: number): Promise<JsonApiEntity[]> {
+    const response = await this.fetchJson<ResponseMulti>(
+      `/api/teams/${teamId}/relationships/notification`,
+    );
+    return response.data;
+  }
+
+  public async getProjectNotificationConfigurations(projectId: number): Promise<JsonApiEntity[]> {
+    const response = await this.fetchJson<ResponseMulti>(
+      `/api/projects/${projectId}/relationships/notification`,
+    );
+    return response.data;
+  }
+
   public async configureNotification(attributes: NotificationConfiguration): Promise<JsonApiEntity> {
     if (attributes.teamId === null) {
       delete attributes.teamId;

--- a/src/integration-test/types.ts
+++ b/src/integration-test/types.ts
@@ -18,33 +18,21 @@ export interface Config {
     [key: string]: Auth0 & { gitPassword: string };
   };
 }
-
-export type NotificationType = 'flowdock' | 'hipchat' | 'slack';
-
-export interface HipChatNotificationConfiguration extends BaseNotificationConfiguration {
+interface HipChatNotificationConfiguration {
   type: 'hipchat';
   hipchatRoomId: number;
   hipchatAuthToken: string;
 }
 
-export interface FlowdockNotificationConfiguration extends BaseNotificationConfiguration {
+interface FlowdockNotificationConfiguration {
   type: 'flowdock';
   flowToken: string;
 }
 
-export interface SlackNotificationConfiguration extends BaseNotificationConfiguration {
+interface SlackNotificationConfiguration {
   type: 'slack';
   slackWebhookUrl: string;
 }
-
-export interface BaseNotificationConfiguration {
-  type: NotificationType;
-}
-
-export type NotificationConfiguration =
-  HipChatNotificationConfiguration |
-  FlowdockNotificationConfiguration |
-  SlackNotificationConfiguration;
 
 export interface SSE {
   type: string;

--- a/src/json-api/json-api-hapi-plugin.ts
+++ b/src/json-api/json-api-hapi-plugin.ts
@@ -427,6 +427,20 @@ export class JsonApiHapiPlugin {
         },
       },
     }, {
+      method: 'GET',
+      path: '/teams/{teamId}/relationships/notification',
+      handler: {
+        async: this.getTeamNotificationConfigurationsHandler,
+      },
+      config: {
+        bind: this,
+        validate: {
+          params: {
+            teamId: Joi.number().required(),
+          },
+        },
+      },
+    }, {
       method: 'DELETE',
       path: '/notifications/{id}',
       handler: {
@@ -765,6 +779,11 @@ export class JsonApiHapiPlugin {
   public async getProjectNotificationConfigurationsHandler(request: Hapi.Request, reply: Hapi.IReply) {
     const projectId = Number(request.params.projectId);
     return reply(this.getEntity('notification', api => api.getProjectNotificationConfigurations(projectId)));
+  }
+
+  public async getTeamNotificationConfigurationsHandler(request: Hapi.Request, reply: Hapi.IReply) {
+    const teamId = Number(request.params.teamId);
+    return reply(this.getEntity('notification', api => api.getTeamNotificationConfigurations(teamId)));
   }
 
   public async tryGetNotificationConfiguration(request: Hapi.Request, reply: Hapi.IReply) {

--- a/src/json-api/json-api-module.ts
+++ b/src/json-api/json-api-module.ts
@@ -350,6 +350,10 @@ export class JsonApiModule {
     return this.notificationModule.getProjectConfigurations(projectId);
   }
 
+  public async getTeamNotificationConfigurations(teamId: number) {
+    return this.notificationModule.getTeamConfigurations(teamId);
+  }
+
   public async createNotificationConfiguration(config: NotificationConfiguration) {
     return this.notificationModule.addConfiguration(config);
   }

--- a/src/notification/notification-module-spec.ts
+++ b/src/notification/notification-module-spec.ts
@@ -263,7 +263,7 @@ describe('notification-module', () => {
     await shouldNotTriggerNotification(projectId, { screenshotStatus: 'running' });
   });
 
-  it('should be able to add, get and delete configurations', async () => {
+  it('should be able to add, get and delete project scoped configurations', async () => {
     const _projectId = 9;
     // Arrange
     const notificationModule = await arrange({} as any, new LocalEventBus(), {} as any, {} as any);
@@ -293,6 +293,38 @@ describe('notification-module', () => {
     expect(existingForProject[0].slackWebhookUrl).to.equal(config.slackWebhookUrl);
     expect(deleted).to.equal(undefined);
     expect(deletedForProject).to.have.length(0);
+  });
+
+  it('should be able to add, get and delete team scoped configurations', async () => {
+    const _teamId = 9;
+    // Arrange
+    const notificationModule = await arrange({} as any, new LocalEventBus(), {} as any, {} as any);
+    const config = {
+      type: 'slack' as 'slack',
+      projectId: null,
+      flowToken: null,
+      hipchatAuthToken: null,
+      hipchatRoomId: null,
+      slackWebhookUrl: 'http://mock.slack.url/sdadsad',
+      teamId: _teamId,
+    };
+
+    // Act
+    const id = await notificationModule.addConfiguration(config);
+    const existing = await notificationModule.getConfiguration(id);
+    const existingForTeam = await notificationModule.getTeamConfigurations(_teamId);
+    await notificationModule.deleteConfiguration(id);
+    const deleted = await notificationModule.getConfiguration(id);
+    const deletedForTeam = await notificationModule.getTeamConfigurations(_teamId);
+
+    // Assert
+    expect(existing).to.deep.equal({ ...config, id });
+    expect(existing!.slackWebhookUrl).to.equal(config.slackWebhookUrl);
+    expect(existingForTeam).to.have.length(1);
+    expect(existingForTeam[0]).to.deep.equal({ ...config, id });
+    expect(existingForTeam[0].slackWebhookUrl).to.equal(config.slackWebhookUrl);
+    expect(deleted).to.equal(undefined);
+    expect(deletedForTeam).to.have.length(0);
   });
 
 });


### PR DESCRIPTION
This PR adds a new endpoint `GET /api/teams/{teamId}/relationships/notification`, which lists the team scoped notification configurations. This complements the existing `GET /api/projects/{projectId}/relationships/notification` endpoint for listing project scoped notification configurations.

More complete documentation is included in https://github.com/lucified/minard-backend/blob/notificationconf-listing/docs/api/api-notification.md.

Also included are integration tests for notification configuration listings.