### PR TITLE
Don't leak GitLab-specific information in team endpoint

### DIFF
--- a/src/authentication/authentication-hapi-plugin-spec.ts
+++ b/src/authentication/authentication-hapi-plugin-spec.ts
@@ -247,10 +247,16 @@ describe('authentication-hapi-plugin', () => {
     it('should be able to fetch caller\'s team', async () => {
       // Arrange
       const callerTeamId = 1;
+      const callerTeamName = 'teamname';
+      const callerTeamDescription = 'team description';
       const { server, plugin } = await getServer(
         (p: AuthenticationHapiPlugin) => [
           sinon.stub(p, '_getUserGroups')
-            .returns(Promise.resolve([{ id: callerTeamId, name: 'foo' }])),
+            .returns(Promise.resolve([{
+              id: callerTeamId,
+              name: callerTeamName,
+              description: callerTeamDescription,
+            }])),
         ],
       );
 
@@ -262,6 +268,8 @@ describe('authentication-hapi-plugin', () => {
       expect(plugin._getUserGroups).to.have.been.calledOnce;
       const team = JSON.parse(response.payload);
       expect(team.id).to.eq(callerTeamId);
+      expect(team.name).to.eq(callerTeamName);
+      expect(team.description).to.eq(callerTeamDescription);
     });
 
     it('should return the team\'s teamToken', async () => {

--- a/src/authentication/authentication-hapi-plugin.ts
+++ b/src/authentication/authentication-hapi-plugin.ts
@@ -250,7 +250,7 @@ class AuthenticationHapiPlugin extends HapiPlugin {
         (teamTokenResult && teamTokenResult.length) ? teamTokenResult[0].token : undefined;
       return reply({
         id: team.id,
-        name: team.id,
+        name: team.name,
         description: team.description,
         avatar_url: team.avatar_url,
         'invitation-token': teamToken,

--- a/src/authentication/authentication-hapi-plugin.ts
+++ b/src/authentication/authentication-hapi-plugin.ts
@@ -248,7 +248,13 @@ class AuthenticationHapiPlugin extends HapiPlugin {
       const teamTokenResult = await teamTokenQuery(this.db, { teamId: team.id });
       const teamToken =
         (teamTokenResult && teamTokenResult.length) ? teamTokenResult[0].token : undefined;
-      return reply({ ...team, 'invitation-token': teamToken });
+      return reply({
+        id: team.id,
+        name: team.id,
+        description: team.description,
+        avatar_url: team.avatar_url,
+        'invitation-token': teamToken,
+      });
     } catch (error) {
       this.logger.error(`Can't fetch user or team`, error);
       return reply(Boom.wrap(error, 404));


### PR DESCRIPTION
`/team` was returning information that is not used by minard-ui such as `web_url`. This field contained an internal GitLab URL that should not be visible to users. Fix this.