### PR TITLE
Double screenshot delay to 10 seconds

### DIFF
--- a/src/screenshot/screenshot-module.ts
+++ b/src/screenshot/screenshot-module.ts
@@ -85,7 +85,7 @@ export default class ScreenshotModule {
     const dest = this.getRemoteDest(projectId, deploymentId);
     const options: PageresOptions = {
       filename: stripExtension(this.getScreenshotFilename(projectId, deploymentId)),
-      delay: 5,
+      delay: 10,
       format: 'jpg',
     };
     try {


### PR DESCRIPTION
The loading of some projects can take a while. Increase the delay before the screenshot is taken to increase the likelihood of seeing something in the screenshot.