### PR TITLE
Admin access and cli

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,7 +202,7 @@ services:
       - EXTERNAL_GIT_BASEURL=http://git.localtest.me:8000
       - GITLAB_ROOT_PASSWORD=12345678
       - SENTRY_DSN=$SENTRY_DSN
-      - ADMIN_TEAM_NAME=integrationtestadminteam
+      - ADMIN_ID=9A0cjUjLPIAIP52xTTWvuakblphA8EYu
       - OPEN_TEAM_NAMES=integrationtestopenteam
       - EXIT_DELAY=0
       - DEBUG=1

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -24,9 +24,9 @@ interface Config {
     },
   };
   auth0: {
-    regular: Auth0 & { gitPassword: string };
-    open: Auth0 & { gitPassword: string };
-    admin: Auth0 & { gitPassword: string };
+    regular: Auth0;
+    open: Auth0;
+    admin: Auth0;
   };
 }
 interface Auth0 {
@@ -56,17 +56,24 @@ to the integration test configuration file described above.
 
 ## GitLab configuration
 
-Create three new groups, 'integrationtest', 'integrationtestopen' and 'integrationtestadmin'.
+Create two new groups, 'integrationtest' and 'integrationtestopen'.
 Add a user to each of these and set the username to `clients-{clientId}` where clientId
-is the id of the corresponding Auth0 client. Set the user's password to some generated value and
-copy it to the `gitPassword` field of the corresponding team in the `auth0` block
-of the configuration file.
+is the id of the corresponding Auth0 client. Additionally, create one more new user, which
+you don't need add to any group. This will be admin user.
+
+After setting up these configuration, update the passwords for all users
+by running:
+
+```shell
+charles-client regenerateGitlabPasswords
+```
 
 ## Charles's configuration
 
 Make sure the following environment variables have been set when starting charles:
 
 ```shell
+ADMIN_ID=auth0ClientIdForAdminUser
 OPEN_TEAM_NAMES=integrationtestopenteam
 ADMIN_TEAM_NAME=integrationtestadminteam
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,12 @@
       "integrity": "sha1-ox10JBprHtu5c8822XooloNKUfk=",
       "dev": true
     },
+    "@types/commander": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@types/commander/-/commander-2.9.1.tgz",
+      "integrity": "sha512-P4s1aEJYjHB1pmS5th4WXQ/NEYykK1FmCFJL+NIrDCptWs2DIS/SsVjmaubvcWZ17VzlG+CwiAv52ghkfkepWA==",
+      "dev": true
+    },
     "@types/debug": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.29.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "cache-manager": "^2.4.0",
     "cache-manager-redis": "^0.4.0",
     "chalk": "^1.1.3",
+    "commander": "^2.9.0",
     "datauri": "^1.0.5",
     "deepcopy": "^0.6.3",
     "eventstore": "^1.12.3",
@@ -56,6 +57,7 @@
     "@types/cache-manager": "^1.2.4",
     "@types/chai": "^3.5.1",
     "@types/chalk": "^0.4.31",
+    "@types/commander": "^2.9.1",
     "@types/debug": "0.0.29",
     "@types/fetch-mock": "^5.8.2",
     "@types/form-data": "0.0.33",
@@ -122,5 +124,8 @@
     "type": "git",
     "url": "git+https://github.com/lucified/minard-backend.git"
   },
-  "license": ""
+  "license": "",
+  "bin": {
+    "charles-client": "dist/cli/index.js"
+  }
 }

--- a/src/authentication/authentication-hapi-plugin-spec.ts
+++ b/src/authentication/authentication-hapi-plugin-spec.ts
@@ -11,7 +11,7 @@ import { bootstrap } from '../config';
 import { getAccessToken, getSignedAccessToken } from '../config/config-test';
 import { getTestServer } from '../server/hapi';
 import { makeRequestWithAuthentication, MethodStubber, stubber } from '../shared/test';
-import { adminTeamNameInjectSymbol, charlesKnexInjectSymbol, openTeamNamesInjectSymbol } from '../shared/types';
+import { adminIdInjectSymbol, charlesKnexInjectSymbol, openTeamNamesInjectSymbol } from '../shared/types';
 import {
   accessTokenCookieSettings,
   default as AuthenticationHapiPlugin,
@@ -717,7 +717,7 @@ describe('authentication-hapi-plugin', () => {
       const { plugin } = await getPlugin(
         (p: AuthenticationHapiPlugin, k: Container) => [
           stub(p, '_getUserGroups')
-            .returns(Promise.resolve([{ id: 1, name: k.get<string>(adminTeamNameInjectSymbol) }])),
+            .returns(Promise.resolve([{ id: 1, name: k.get<string>(adminIdInjectSymbol) }])),
         ],
       );
 
@@ -733,7 +733,7 @@ describe('authentication-hapi-plugin', () => {
       const { plugin } = await getPlugin(
         (p: AuthenticationHapiPlugin, k: Container) => [
           stub(p, '_getUserGroups')
-            .returns(Promise.resolve([{ id: 1, name: k.get<string>(adminTeamNameInjectSymbol) + '1' }])),
+            .returns(Promise.resolve([{ id: 1, name: k.get<string>(adminIdInjectSymbol) + '1' }])),
         ],
       );
 

--- a/src/authentication/authentication-hapi-plugin-spec.ts
+++ b/src/authentication/authentication-hapi-plugin-spec.ts
@@ -40,7 +40,7 @@ async function getPlugin(authenticationStubber?: MethodStubber<AuthenticationHap
   await initializeTeamTokenTable(db);
   if (authenticationStubber) {
     const { instance } = stubber(authenticationStubber, AuthenticationHapiPlugin.injectSymbol, kernel);
-    return { plugin: instance, db };
+    return { plugin: instance, db, kernel };
   }
   const plugin = kernel.get<AuthenticationHapiPlugin>(AuthenticationHapiPlugin.injectSymbol);
   return { plugin, db, kernel };
@@ -711,54 +711,29 @@ describe('authentication-hapi-plugin', () => {
 
   });
   describe('_isAdmin', () => {
-    it('returns true if the user belongs to a team with the correct name', async () => {
+    it('returns true when called with the bound value of adminIdInjectSymbol prepended with \'clients-\'', async () => {
 
       // Arrange
-      const { plugin } = await getPlugin(
-        (p: AuthenticationHapiPlugin, k: Container) => [
-          stub(p, '_getUserGroups')
-            .returns(Promise.resolve([{ id: 1, name: k.get<string>(adminIdInjectSymbol) }])),
-        ],
-      );
+      const { plugin, kernel } = await getPlugin();
+      const adminId = kernel.get<string>(adminIdInjectSymbol);
 
       // Act
-      const result = await plugin._isAdmin('foo');
+      const result = await plugin._isAdmin(`clients-${adminId}`);
 
       // Assert
       expect(result).to.be.true;
     });
-    it('returns false if the user belongs to a team with an incorrect name', async () => {
+    it('returns false if called with some other value', async () => {
 
       // Arrange
-      const { plugin } = await getPlugin(
-        (p: AuthenticationHapiPlugin, k: Container) => [
-          stub(p, '_getUserGroups')
-            .returns(Promise.resolve([{ id: 1, name: k.get<string>(adminIdInjectSymbol) + '1' }])),
-        ],
-      );
+      const { plugin, kernel } = await getPlugin();
+      const adminId = kernel.get<string>(adminIdInjectSymbol);
 
       // Act
-      const result = await plugin._isAdmin('foo');
+      const result = await plugin._isAdmin(adminId + 'x');
 
       // Assert
       expect(result).to.be.false;
-    });
-    it('throws if something unexpected happens', async () => {
-
-      // Arrange
-      const { plugin } = await getPlugin(
-        (p: AuthenticationHapiPlugin) => [
-          stub(p, '_getUserGroups')
-            .returns(Promise.reject(badGateway())),
-        ],
-      );
-
-      // Act
-      const resultPromise = plugin._isAdmin('foo');
-
-      // Assert
-      return resultPromise
-        .then(_ => expect.fail(), error => expect(error.isBoom).to.be.true);
     });
   });
   describe('isOpenDeployment', () => {

--- a/src/authentication/authentication-hapi-plugin.ts
+++ b/src/authentication/authentication-hapi-plugin.ts
@@ -12,7 +12,7 @@ import { Group } from '../shared/gitlab';
 import { GitlabClient, looselyValidateEmail } from '../shared/gitlab-client';
 import { Logger, loggerInjectSymbol } from '../shared/logger';
 import {
-  adminTeamNameInjectSymbol,
+  adminIdInjectSymbol,
   charlesKnexInjectSymbol,
   fetchInjectSymbol,
   openTeamNamesInjectSymbol,
@@ -56,7 +56,7 @@ class AuthenticationHapiPlugin extends HapiPlugin {
     @inject(auth0AudienceInjectSymbol) private readonly auth0Audience: string,
     @inject(charlesKnexInjectSymbol) private readonly db: Knex,
     @inject(loggerInjectSymbol) private readonly logger: Logger,
-    @inject(adminTeamNameInjectSymbol) private readonly adminTeamName: string,
+    @inject(adminIdInjectSymbol) private readonly adminId: string,
     @inject(openTeamNamesInjectSymbol) private readonly openTeamNames: string[],
     @inject(fetchInjectSymbol) private readonly fetch: IFetch,
     @inject(internalHostSuffixesInjectSymbol) private readonly internalHostSuffixes: string[],
@@ -702,11 +702,7 @@ class AuthenticationHapiPlugin extends HapiPlugin {
 
   // Public only for unit testing
   public async _isAdmin(userName: string) {
-    const teams = await this._getUserGroups(userName);
-    if (teams && teams.find(findTeamByName(this.adminTeamName)) !== undefined) {
-      return true;
-    }
-    return false;
+    return Promise.resolve(userName === `clients-${this.adminId}`);
   }
 
   // Public only for unit testing

--- a/src/authentication/cached-authentication-hapi-plugin.ts
+++ b/src/authentication/cached-authentication-hapi-plugin.ts
@@ -8,7 +8,7 @@ import { IFetch } from '../shared/fetch';
 import { GitlabClient } from '../shared/gitlab-client';
 import { Logger, loggerInjectSymbol } from '../shared/logger';
 import {
-  adminTeamNameInjectSymbol,
+  adminIdInjectSymbol,
   charlesKnexInjectSymbol,
   fetchInjectSymbol,
   openTeamNamesInjectSymbol,
@@ -34,7 +34,7 @@ class CachedAuthenticationHapiPlugin extends AuthenticationHapiPlugin {
     @inject(auth0AudienceInjectSymbol) auth0Audience: string,
     @inject(charlesKnexInjectSymbol) db: Knex,
     @inject(loggerInjectSymbol) logger: Logger,
-    @inject(adminTeamNameInjectSymbol) adminTeamName: string,
+    @inject(adminIdInjectSymbol) adminTeamName: string,
     @inject(openTeamNamesInjectSymbol) openTeamNames: string[],
     @inject(fetchInjectSymbol) fetch: IFetch,
     @inject(internalHostSuffixesInjectSymbol) internalHostSuffixes: string[],

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+import * as program from 'commander';
+import * as _debug from 'debug';
+import CharlesClient from '../integration-test/charles-client';
+import { CharlesResponse } from '../integration-test/types';
+import { getAccessToken, getConfiguration } from '../integration-test/utils';
+
+const debug = _debug('charles-client');
+
+program
+  .version('0.0.1')
+  .description(
+    `Provides a cli interface for CharlesClient.
+  The specified method is called with the given arguments and the output json
+  is printed to stdout. See the CharlesClient class for the methods and
+  their arguments.
+
+  The authentication is handled by the same mechanism as in the integration tests,
+  i.e. with the configuration files 'src/integration-test/configuration.<env>.ts',
+  where env is one of 'development (default) | staging | production' and checked
+  from the 'NODE_ENV' environment variable.
+
+
+  Examples:
+  charles-client getTeamToken lucify
+  charles-client createTeamToken lucify
+    `,
+  )
+  .usage('<method> [arguments]')
+  .action(run());
+
+program.parse(process.argv);
+
+function run() {
+  return (...cliArgs: any[]) => {
+    const fn = async () => {
+      cliArgs.pop();
+      const methodName = cliArgs.shift();
+      debug(`Calling '%s' with args %s`, methodName, cliArgs.map(a => `'${a}'`).join(', '));
+      try {
+        const config = await getConfiguration(
+          process.env.NODE_ENV || 'development',
+        );
+        const accessToken = await getAccessToken(config.auth0.admin);
+        const client = new CharlesClient(config.charles, accessToken);
+        const response: CharlesResponse<any> = await (client as any)[methodName](cliArgs);
+        const json = await response.toJson();
+        return console.log(json);
+      } catch (error) {
+        return console.error(error.message);
+      }
+    };
+    return fn();
+  };
+}

--- a/src/config/config-production.ts
+++ b/src/config/config-production.ts
@@ -46,7 +46,7 @@ import {
   tokenSecretInjectSymbol,
 } from '../shared/token-generator';
 import {
-  adminTeamNameInjectSymbol,
+  adminIdInjectSymbol,
   charlesDbNameInjectSymbol,
   charlesKnexInjectSymbol,
   gitlabKnexInjectSymbol,
@@ -291,7 +291,7 @@ const EXIT_DELAY = env.EXIT_DELAY ? parseInt(env.EXIT_DELAY, 10) : 15000;
 // Admin team name
 // --------------
 
-const ADMIN_TEAM_NAME = env.ADMIN_TEAM_NAME || 'lucify';
+const ADMIN_ID = env.ADMIN_ID;
 
 // The names of teams that should have open (= no auth required) deployments
 // --------------
@@ -332,7 +332,7 @@ export default (kernel: Container) => {
   kernel.bind(auth0ClientIdInjectSymbol).toConstantValue(AUTH0_CLIENT_ID);
   kernel.bind(auth0AudienceInjectSymbol).toConstantValue(AUTH0_AUDIENCE);
   kernel.bind(authCookieDomainInjectSymbol).toConstantValue(AUTH_COOKIE_DOMAIN);
-  kernel.bind(adminTeamNameInjectSymbol).toConstantValue(ADMIN_TEAM_NAME);
+  kernel.bind(adminIdInjectSymbol).toConstantValue(ADMIN_ID);
   kernel.bind(openTeamNamesInjectSymbol).toConstantValue(OPEN_TEAM_NAMES);
   kernel.bind(internalHostSuffixesInjectSymbol).toConstantValue(INTERNAL_HOST_SUFFIXES.split(','));
 };

--- a/src/integration-test/git-authentication-tests.ts
+++ b/src/integration-test/git-authentication-tests.ts
@@ -8,30 +8,37 @@ import { getConfiguration } from './utils';
  * because they are run against the actual Auth0 backend
  */
 
-const config = getConfiguration(process.env.NODE_ENV);
-const { domain, audience, clientId, clientSecret } = config.auth0.regular;
-
-const credentialsList: {
-  description: string;
-  id: string;
-  secret: string;
-}[] = [
-  {
-    description: 'user',
-    id: process.env.USERNAME,
-    secret: process.env.PASSWORD,
-  },
-  {
-    description: 'client',
-    id: clientId,
-    secret: clientSecret,
-  },
-];
-
 describe('git-authentication', () => {
   let scheme: GitAuthScheme;
   let accessToken: string;
   let signingKey: string;
+  let domain: string;
+  let audience: string;
+  let credentialsList: {
+    description: string;
+    id: string;
+    secret: string;
+  }[] = [];
+
+  before(async () => {
+    const config = await getConfiguration(process.env.NODE_ENV);
+    const { clientId, clientSecret } = config.auth0.regular;
+    domain = config.auth0.regular.domain;
+    audience = config.auth0.regular.audience;
+    credentialsList = [
+      {
+        description: 'user',
+        id: process.env.USERNAME,
+        secret: process.env.PASSWORD,
+      },
+      {
+        description: 'client',
+        id: clientId,
+        secret: clientSecret,
+      },
+    ];
+  });
+
   beforeEach(() => {
     scheme = new GitAuthScheme(
       'ZaeiNyV7S7MpI69cKNHr8wXe5Bdr8tvW',

--- a/src/integration-test/index.ts
+++ b/src/integration-test/index.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import CharlesClient from './charles-client';
 import interTeamTests from './tests-inter-team';
 import intraTeamTests from './tests-intra-team';
-import { CharlesClients } from './types';
+import { CharlesClients, Config } from './types';
 import {
   getAccessToken,
   getAnonymousClient,
@@ -17,7 +17,6 @@ import {
 const cacheDir = join(__dirname, '.cache');
 const cacheFileName = 'integration-tests-cache.json';
 const _saveToCache = saveToCache(cacheDir, cacheFileName);
-const config = getConfiguration(process.env.NODE_ENV);
 
 function hasInterTeamClients(
   clients: Partial<CharlesClients>,
@@ -28,6 +27,12 @@ function hasInterTeamClients(
 describe('system-integration', () => {
   const clientTypes: (keyof CharlesClients)[] = ['regular', 'admin', 'open'];
   let clients: Partial<CharlesClients> = {};
+  let config: Config;
+
+  before(async () => {
+    config = await getConfiguration(process.env.NODE_ENV);
+  });
+
   describe('intra-team', () => {
     for (const clientType of clientTypes) {
       describe(`user belonging to '${clientType}' team`, () => {

--- a/src/integration-test/index.ts
+++ b/src/integration-test/index.ts
@@ -42,10 +42,9 @@ describe('system-integration', () => {
           }
         });
 
-        const auth0Config = config.auth0[clientType];
-
         describe('authentication', () => {
           it('should be able to sign in with Auth0', async function() {
+            const auth0Config = config.auth0[clientType];
             this.timeout(1000 * 30);
             const accessToken = await getAccessToken(auth0Config);
             expect(accessToken).to.exist;
@@ -57,9 +56,8 @@ describe('system-integration', () => {
         });
         intraTeamTests(
           () => Promise.resolve(clients[clientType]!),
-          auth0Config.clientId,
-          auth0Config.clientSecret,
-          config.notifications,
+          () => Promise.resolve(config.auth0[clientType]!),
+          () => Promise.resolve(config.notifications),
         );
       });
     }

--- a/src/integration-test/tests-intra-team.ts
+++ b/src/integration-test/tests-intra-team.ts
@@ -4,14 +4,13 @@ import * as debug from 'debug';
 import { JsonApiEntity } from '../json-api/types';
 import { NotificationConfiguration, NotificationType } from '../notification/types';
 import CharlesClient from './charles-client';
-import { LatestDeployment, NotificationConfigurations, SSE } from './types';
+import { Auth0, LatestDeployment, NotificationConfigurations, SSE } from './types';
 import { runCommand, withPing } from './utils';
 
 export default (
   clientFactory: () => Promise<CharlesClient>,
-  gitUser: string,
-  gitPassword: string,
-  notificationConfigurations?: NotificationConfigurations,
+  credentialsFactory: () => Promise<Auth0>,
+  notifications: () => Promise<NotificationConfigurations>,
   projectName = 'regular-project',
 ) => {
 
@@ -93,10 +92,11 @@ export default (
   describe('deployments', () => {
     it('should be able to create a successful deployment by pushing code', async function () {
       const client = await clientFactory();
+      const { clientId, clientSecret } = await credentialsFactory();
       this.timeout(1000 * 60 * 5);
       debug('Pushing code');
       const repoFolder = `src/integration-test/blank`;
-      const repoUrl = client.getRepoUrlWithCredentials(gitUser, gitPassword);
+      const repoUrl = client.getRepoUrlWithCredentials(clientId, clientSecret);
       await runCommand('src/integration-test/setup-repo');
       await runCommand('git', '-C', repoFolder, 'remote', 'add', 'minard', repoUrl);
       await runCommand('git', '-C', repoFolder, 'push', 'minard', 'master');
@@ -182,6 +182,7 @@ export default (
 
     it('should be able to configure notifications', async function () {
       const client = await clientFactory();
+      const notificationConfigurations = await notifications();
       if (!notificationConfigurations) {
         this.skip();
         return;

--- a/src/integration-test/types.ts
+++ b/src/integration-test/types.ts
@@ -90,3 +90,8 @@ export interface LatestProject {
   repoUrl: string;
   token: string;
 }
+
+export interface OperationsResponse {
+  status: number;
+  message: string;
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -5,5 +5,5 @@ export const charlesKnexInjectSymbol = Symbol('charles-knex');
 export const charlesDbNameInjectSymbol = Symbol('charles-db-name');
 export const gitlabKnexInjectSymbol = Symbol('gitlab-knex');
 export const postgresKnexInjectSymbol = Symbol('postgres-knex');
-export const adminTeamNameInjectSymbol = Symbol('admin-team-name');
+export const adminIdInjectSymbol = Symbol('admin-team-name');
 export const openTeamNamesInjectSymbol = Symbol('open-team-names');


### PR DESCRIPTION
Have a single admin user instead of an admin team.  This is motivated by all the drawbacks of having an admin access by default, e.g. accidents.

This builds on the previous work for authenticating the integration tests with the '[Client Credentials Grant](https://auth0.com/docs/api-auth/grant/client-credentials)'.

This PR adds a way to call (a subset of) charles's api as an admin from the command line. The cli uses the same configuration as the integration tests and the environment is selected with the `NODE_ENV` environment variable. I suggest 'installing' the executable like this:

```shell
npm install # creates node_modules/.bin/charles-client
npm link # symlinks the above executable globally
```
Assuming you have the configuration file `src/integration-tests/configuration.development.ts` setup with the admin credentials and team 'lucify' defined locally, you should be able call
```shell
charles-client createTeamToken lucify
```
