### PR TITLE
Better http response codes

### DIFF
--- a/src/authentication/raw-deployment-authorization-spec.ts
+++ b/src/authentication/raw-deployment-authorization-spec.ts
@@ -87,7 +87,7 @@ describe('authorization for raw deployments', () => {
     // Act
     const response = await makeRequest(server);
     // Assert
-    expect(response.statusCode).to.eq(401);
+    expect(response.statusCode).to.eq(404);
     expect(authentication.userHasAccessToDeployment).to.have.been.calledOnce;
     expect(handlerStub).to.not.have.been.called;
 

--- a/src/integration-test/charles-client.ts
+++ b/src/integration-test/charles-client.ts
@@ -438,8 +438,7 @@ export default class CharlesClient {
     const url = path.match(/^http/) ? path : `${this.url}${path}`;
     const response = wrapResponse<T>(await this.rawFetch(url, options));
     if (this.verbose) {
-      log(`\u21e2 ${prettyUrl(url)}`);
-      log(`\u21e0 ${response.status}`);
+      log(`\u21e0 ${response.status} ${prettyUrl(url)}`);
     }
 
     if (this.throwOnUnsuccessful) {

--- a/src/integration-test/index.ts
+++ b/src/integration-test/index.ts
@@ -55,6 +55,7 @@ describe('system-integration', () => {
               config.charles,
               accessToken,
               true,
+              isDebug(),
             );
           });
         });

--- a/src/integration-test/tests-inter-team.ts
+++ b/src/integration-test/tests-inter-team.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import routes, { codes } from './routes';
 import { CharlesClients, EntityType, UserType } from './types';
-import { runCommand } from './utils';
+import { isDebug, runCommand } from './utils';
 
 export default (
   clientsFactory: () => Promise<CharlesClients>,
@@ -28,7 +28,10 @@ export default (
                   requestor,
                   getOwnerClient(userType, entityType, clients),
                 );
-                expect(response.status).to.eq(expectedCode);
+                expect(
+                  response.status,
+                  isDebug() ? await response.text() : '',
+                ).to.eq(expectedCode);
               });
             });
           }

--- a/src/integration-test/utils.ts
+++ b/src/integration-test/utils.ts
@@ -79,11 +79,11 @@ export async function runCommand(command: string, ...args: string[]): Promise<bo
 }
 
 export function log(text: string) {
-  debug(`    ${cyan(text)}`);
+  debug(`${cyan(text)}`);
 }
 
 export function logTitle(text: string) {
-  debug(`   ${magenta(text)}`);
+  debug(`${magenta(text)}`);
 }
 
 export function prettyUrl(url: string) {
@@ -216,7 +216,7 @@ export function getAnonymousClient(client: CharlesClient) {
   anonymous.lastDeployment = {
     id: '9999999',
     url: anonymousUrl,
-    screenshot: client.lastDeployment!.screenshot + '_',
+    screenshot: client.lastDeployment!.screenshot + 'X',
     token: '9999999',
   };
   return anonymous;
@@ -231,6 +231,7 @@ export function cloneCharlesClient(client: CharlesClient, throwOnUnsuccessful = 
     client.url,
     client.accessToken,
     throwOnUnsuccessful,
+    client.verbose,
   );
   clone.teamId = client.teamId;
   clone.lastCreatedProject = client.lastCreatedProject;

--- a/src/screenshot/screenshot-hapi-plugin.ts
+++ b/src/screenshot/screenshot-hapi-plugin.ts
@@ -1,4 +1,4 @@
-import { forbidden, notFound } from 'boom';
+import { notFound } from 'boom';
 import { inject, injectable } from 'inversify';
 import * as Joi from 'joi';
 
@@ -52,7 +52,7 @@ export default class ScreenshotHapiPlugin {
       throw notFound();
     }
     if (!this.screenshotModule.isValidToken(projectId, deploymentId, token)) {
-      throw forbidden('Invalid token');
+      throw notFound();
     }
     const path = this.screenshotModule.getScreenshotPath(projectId, deploymentId);
     return reply.file(path, { confine: false } as any);

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -1,0 +1,25 @@
+import { BoomError } from 'boom';
+import { Response} from 'hapi';
+
+export function maskErrors(
+  response: Response,
+) {
+  if (response.isBoom) {
+    const boomError = (response as any) as BoomError;
+    const { output } = boomError;
+    if (output.statusCode >= 401 && output.statusCode < 500) {
+      output.statusCode = 404;
+      boomError.reformat();
+    }
+    const _output = output as any;
+    _output.payload = {
+      errors: [
+        {
+          title: output.payload.error,
+          status: output.statusCode,
+          detail: '',
+        },
+      ],
+    };
+  }
+}


### PR DESCRIPTION
## Description
Always show 401 Unauthorized and 403 Forbidden responses as 404.
Also improve the output of the integration tests in debug mode.

## How to test
```shell
DEBUG=system-integration-tests npm run system-test
```
All the tests should now pass.