### PR TITLE
Minimize slack notification

### DIFF
--- a/src/notification/slack-notify-spec.ts
+++ b/src/notification/slack-notify-spec.ts
@@ -20,7 +20,6 @@ describe('slack-notify', () => {
     buildStatus: 'success',
     extractionStatus: 'success',
     screenshotStatus: 'failed',
-    screenshot: 'http://foo-deployentm.com/screenshot.jpg',
     createdAt: moment(),
     commit: {
       id: 'foo-id',
@@ -58,7 +57,7 @@ describe('slack-notify', () => {
     return { notifier, promise };
   }
 
-  it('should send correct notification for deployment with screenshot', async () => {
+  it('should send correct notification for deployment', async () => {
     // Arrange
     const { notifier, promise } = arrange();
 
@@ -86,9 +85,8 @@ describe('slack-notify', () => {
     expect(attachment.fallback).contains('preview');
     expect(attachment.color).equal('#40C1AC');
     expect(attachment.author_name).equal(deployment.commit.committer.name);
-    expect(attachment.title).equal('New preview');
+    expect(attachment.title).equal('New preview in ' + deployment.projectName + '/' + deployment.ref);
     expect(attachment.title_link).equal(previewUrl);
-    expect(attachment.image_url).equal(deployment.screenshot);
     expect(attachment.ts).equal(deployment.createdAt.unix());
   });
 
@@ -126,7 +124,7 @@ describe('slack-notify', () => {
     expect(attachment.fallback).contains('comment');
     expect(attachment.color).equal('#40C1AC');
     expect(attachment.author_name).equal(comment.name);
-    expect(attachment.title).equal('New comment');
+    expect(attachment.title).equal('New comment in ' + deployment.projectName + '/' + deployment.ref);
     expect(attachment.title_link).equal(commentUrl);
     expect(attachment.image_url).equal(deployment.screenshot);
     // TODO: check timestamp?

--- a/src/notification/slack-notify.ts
+++ b/src/notification/slack-notify.ts
@@ -6,7 +6,7 @@ import { IFetch } from '../shared/fetch';
 import { fetchInjectSymbol } from '../shared/types';
 import { NotificationComment, SlackAttachment, SlackMessage } from './types';
 
-export function getMessage(
+function getMessage(
   deployment: MinardDeployment,
   previewUrl: string,
   _projectUrl: string, // leaving in to have a similar structure to Flowdock notifications
@@ -18,12 +18,9 @@ export function getMessage(
     `New ${comment ? 'comment' : 'preview'} in ` +
     `${deployment.projectName}/${deployment.ref}: ${previewUrl}`;
   const previewTitle =
-    'New ' +
-    (comment ? 'comment' : 'preview') +
-    ' in ' +
-    deployment.projectName +
-    '/' +
-    deployment.ref;
+    `New ${comment ? 'comment' : 'preview'} in ` +
+    `${deployment.projectName}/${deployment.ref}`;
+
   const message: SlackAttachment = {
     fallback,
     color: '#40C1AC',

--- a/src/notification/slack-notify.ts
+++ b/src/notification/slack-notify.ts
@@ -9,8 +9,6 @@ import { NotificationComment, SlackAttachment, SlackMessage } from './types';
 function getMessage(
   deployment: MinardDeployment,
   previewUrl: string,
-  _projectUrl: string, // leaving in to have a similar structure to Flowdock notifications
-  _branchUrl: string, // same ^
   comment?: NotificationComment,
 ): SlackMessage {
   const author = comment || deployment.commit.author;
@@ -61,8 +59,8 @@ export class SlackNotify {
   public async notify(
     deployment: MinardDeployment,
     webhookUrl: string,
-    projectUrl: string,
-    branchUrl: string,
+    _projectUrl: string,
+    _branchUrl: string,
     previewUrl: string,
     commentUrl?: string,
     comment?: NotificationComment,
@@ -76,8 +74,6 @@ export class SlackNotify {
     const body = getMessage(
       deployment,
       fullPreviewUrl,
-      projectUrl,
-      branchUrl,
       comment,
     );
 

--- a/src/notification/types.ts
+++ b/src/notification/types.ts
@@ -49,7 +49,7 @@ export interface SlackAttachment {
   title?: string;
   title_link?: string;
   text?: string; // "Optional text that appears within the attachment",
-  fields: { title: string; value: string; short?: boolean }[];
+  fields?: { title: string; value: string; short?: boolean }[];
   // Large images will be resized to a maximum width of 400px or a maximum height of 500px,
   // while still maintaining the original aspect ratio.
   image_url?: string;


### PR DESCRIPTION
Move notification integration tests so that new previews are made while testing

## Description
* Removed screenshot and unnecessary fields in slack notifications
* Change "Commit" field to "Preview:". The user comments on a preview, not a commit.

## How to test
Run integration tests and see testing channel in Lucify Slack

## TODO
- [ ] todoitem
