### PR TITLE
Fix return code

### DIFF
--- a/src/integration-test/charles-client.ts
+++ b/src/integration-test/charles-client.ts
@@ -125,6 +125,30 @@ export default class CharlesClient {
   }
 
   /**
+   * PREVIEW
+   *
+   * All of the project-related functions either perform actions on the project
+   * for the supplied project ID or then on the last project that was created by
+   * CharlesClient.
+   */
+
+  public getPreview(deploymentId?: string, deploymentToken?: string) {
+    const _deploymentId =
+      deploymentId || (this.lastDeployment && this.lastDeployment.id);
+    if (!_deploymentId) {
+      throw new Error('No deploymentId available');
+    }
+    const _deploymentToken =
+      deploymentToken || (this.lastDeployment && this.lastDeployment.token);
+    if (!_deploymentToken) {
+      throw new Error('No deploymentToken available');
+    }
+    return this.fetch<ResponseSingle>(
+      `/api/preview/deployment/${_deploymentId}/${deploymentToken}`,
+    );
+  }
+
+  /**
    * Calling this sets this.lastProject.
    */
   public async createProject(

--- a/src/integration-test/routes.ts
+++ b/src/integration-test/routes.ts
@@ -43,6 +43,22 @@ const routes: Route[] = [
     },
   },
   {
+    description: 'view preview',
+    request: (me: CharlesClient, other: CharlesClient) => {
+      expect(me.lastDeployment).to.exist;
+      expect(other.lastDeployment).to.exist;
+      return me.getPreview(
+        other.lastDeployment!.id,
+        other.lastDeployment!.token,
+      );
+    },
+    accessMatrix: {
+      regular: { own: '1', closed: 'x', open: '1', missing: 'x' },
+      admin: { own: '1', closed: '1', open: '1', missing: 'x' },
+      unauthenticated: { own: 'x', closed: '0', open: '1', missing: 'x' },
+    },
+  },
+  {
     description: 'view screenshot',
     request: (me: CharlesClient, other: CharlesClient) => {
       expect(me.lastDeployment).to.exist;
@@ -61,5 +77,6 @@ export const codes = {
   '1': 200,
   x: 404,
   r: 302,
+  '0': 401,
 };
 export default routes;

--- a/src/integration-test/types.ts
+++ b/src/integration-test/types.ts
@@ -59,7 +59,7 @@ export interface CharlesResponse<T> extends Response {
   getEntities: () => Promise<JsonApiEntity[]>;
 }
 
-export type AccessCode = '1' | 'x' | 'r';
+export type AccessCode = '1' | '0' | 'x' | 'r';
 
 export interface EntityResponse {
   own: AccessCode;

--- a/src/json-api/json-api-hapi-plugin.ts
+++ b/src/json-api/json-api-hapi-plugin.ts
@@ -38,7 +38,15 @@ function onPreResponse(
   }
 
   if (response.isBoom && response.output) {
-    maskErrors(response);
+    // let 401's through to be able to redirect
+    if (
+      request.auth.isAuthenticated ||
+      request.auth.credentials ||
+      response.output.statusCode !== 401 ||
+      !request.path.startsWith('/api/preview')
+    ) {
+      maskErrors(response);
+    }
     applyHeaders(response.output.headers);
   } else {
     applyHeaders(response.headers);

--- a/src/notification/slack-notify-spec.ts
+++ b/src/notification/slack-notify-spec.ts
@@ -85,7 +85,9 @@ describe('slack-notify', () => {
     expect(attachment.fallback).contains('preview');
     expect(attachment.color).equal('#40C1AC');
     expect(attachment.author_name).equal(deployment.commit.committer.name);
-    expect(attachment.title).equal('New preview in ' + deployment.projectName + '/' + deployment.ref);
+    expect(attachment.title).equal(
+      'New preview in ' + deployment.projectName + '/' + deployment.ref,
+    );
     expect(attachment.title_link).equal(previewUrl);
     expect(attachment.ts).equal(deployment.createdAt.unix());
   });
@@ -124,7 +126,9 @@ describe('slack-notify', () => {
     expect(attachment.fallback).contains('comment');
     expect(attachment.color).equal('#40C1AC');
     expect(attachment.author_name).equal(comment.name);
-    expect(attachment.title).equal('New comment in ' + deployment.projectName + '/' + deployment.ref);
+    expect(attachment.title).equal(
+      'New comment in ' + deployment.projectName + '/' + deployment.ref,
+    );
     expect(attachment.title_link).equal(commentUrl);
     expect(attachment.image_url).equal(deployment.screenshot);
     // TODO: check timestamp?

--- a/src/notification/slack-notify.ts
+++ b/src/notification/slack-notify.ts
@@ -71,11 +71,7 @@ export class SlackNotify {
     }
 
     const fullPreviewUrl = commentUrl || previewUrl;
-    const body = getMessage(
-      deployment,
-      fullPreviewUrl,
-      comment,
-    );
+    const body = getMessage(deployment, fullPreviewUrl, comment);
 
     const options = {
       method: 'POST',


### PR DESCRIPTION
## Description
If an unauthenticated user tries to access a closed preview, return 401 instead of 404.

## How to test
Launch minard-backend and minard-ui locally and try to browse to a preview as an unauthenticated user. You should get redirected to a login screen.

